### PR TITLE
Use syntect-compatible Go syntax

### DIFF
--- a/Packages/Go/Go.sublime-syntax
+++ b/Packages/Go/Go.sublime-syntax
@@ -1,487 +1,596 @@
 %YAML 1.2
 ---
 # http://www.sublimetext.com/docs/3/syntax.html
-
-# The structure and terminology of this syntax reflects the spec:
-# https://golang.org/ref/spec
-
-# The following is a simplified model of Sublime Text's syntax engine, reverse-
-# engineered through experience. This model uses assertive language for brevity,
-# but does not reflect the real implementation and should not be taken
-# literally. Still, it helps a LOT, and is necessary for understanding this
-# syntax.
-#
-# The engine has a stack of rulesets. The topmost frame is the current ruleset:
-#
-#   rulesets:
-#     # current
-#     - [
-#       {match: '...', scope: '...'},
-#       {match: '...', scope: '...'},
-#       {match: '...', scope: '...'},
-#     ],
-#     # other
-#     - [...]
-#
-# The engine appears to use three nested loops: (1) lines, (2) character
-# positions, and (3) rules.
-#
-# First, the engine loops through lines. On each line, it loops through char
-# positions. On each char position, it loops through rules. It also loops
-# through rules on at least two special "positions" that don't correspond to a
-# character: start of line and end of line.
-#
-# For each rule, the engine runs its regex against the remainder of the line,
-# which may also start with ^ or consist entirely of $. Note that older syntax
-# engine(s) supported multiline regexes, but this has been deprecated for
-# performance reasons.
-#
-# Each rule may "consume" 0 to N characters, optionally assigning scopes. In
-# addition, the rule may modify the rule stack with `push / pop / set`.
-# Consuming characters advances the character loop. Consuming characters OR
-# modifying the rule stack also resets the RULE loop; the engine will continue
-# from the next character and the FIRST rule in the then-current ruleset.
-#
-# Rules that consume ZERO characters and DON'T modify the stack also DON'T reset
-# the rule loop. We must be mindful of this behavior. Regexes for such rules
-# typically look like this: (?=\S) or $. If they did reset the rule loop, it
-# would cause an infinite loop in the engine.
-#
-# Another potential gotcha: the engine will loop through the rules at the end of
-# each line, where there aren't any characters to match. The only matches are $
-# or its derivatives such as (?=$). Rules intended to work across multiple
-# lines, for example to trim whitespace and comments, may be unexpectedly
-# interrupted by sibling rules with $.
-
-
-
-
+name: Go
 file_extensions:
   - go
+first_line_match: "-[*]-( Mode:)? Go -[*]-"
 scope: source.go
-
 variables:
-  # https://golang.org/ref/spec#Keywords
-  # These are the only words that can't be used as identifiers.
-  keyword: \b(?:break|case|chan|const|continue|default|defer|else|fallthrough|for|func|go|goto|if|import|interface|map|package|range|return|select|struct|switch|type|var)\b
-
-  # https://golang.org/ref/spec#Predeclared_identifiers
-  predeclared_type: \b(?:bool|byte|complex64|complex128|error|float32|float64|int|int8|int16|int32|int64|rune|string|uint|uint8|uint16|uint32|uint64|uintptr)\b
-
-  # https://golang.org/ref/spec#Predeclared_identifiers
-  predeclared_func: \b(?:append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)\b
-
-  # Note: this matches ALL valid identifiers, including predeclared constants,
-  # functions and types.
-  ident: \b(?!{{keyword}})[[:alpha:]_][[:alnum:]_]*\b
-
-  # Single line only
-  inline_comment: /[*](?:[^*]|[*](?!/))*[*]/
-
-  # Whitespace and general comments on a single line.
-  # This should only be used for lookahead, not for capturing / scoping.
-  noise: (?:\s|{{inline_comment}})*
-
-  char_escape: \\x\h{2}|\\u\h{4}|\\U\h{8}|\\[0-7]{3}|\\.
-
-  exponent: '[Ee][+-]?'
+  identifier: '\b[[:alpha:]_][[:alnum:]_]*\b'
+  type_chars: '[[:alnum:]\s,._*&<>\[\]-]'
 
 contexts:
   main:
-    - include: match-any
+    - include: global
 
-  match-any:
-    - include: match-comments
-    - include: match-tokens
+  global:
+    - include: imports
+    - include: functions
+    - include: statements
 
-  # https://golang.org/ref/spec#Comments
-  match-comments:
-    # Go has magic comments in the form of:
-    #
-    # //go:some_directive arg0 arg1 ...
-    #
-    # They're not part of the language spec, may not be recognized by some Go
-    # compilers, and may stop working in future releases. Therefore,
-    # highlighting them as compiler pragmas could be misleading. We scope them
-    # as plain comments by default, and add some detailed meta scopes for
-    # enterprising users wishing to add more color.
-    - match: (//)(go)(:)({{ident}})?
+  statements:
+    - include: expressions-early
+    - include: initializers
+    - include: block
+    - match: ^\s*((?!default){{identifier}})(:)(?!=)
       captures:
-        1: punctuation.definition.comment.go
-        2: meta.keyword.annotation.go
-        3: meta.punctuation.accessor.colon.go
-        4: meta.variable.function.go
+        1: entity.name.label.go
+        2: punctuation.separator.go
+    - match: \b(type)\s+({{identifier}})\s+(struct)\b
+      captures:
+        1: storage.type.go
+        2: entity.name.struct.go
+        3: storage.type.go
       push:
-        - meta_scope: comment.line.go meta.annotation.go
-        - match: \S+
-          scope: meta.variable.parameter.go
-        # End the annotation scope at EOL, but stretch the comment scope
-        # indefinitely to the right.
+        - meta_scope: meta.struct.go
+        - include: comments
+        - match: \}
+          scope: meta.block.go punctuation.definition.block.end.go
+          pop: true
+        - match: \{
+          scope: punctuation.definition.block.begin.go
+          push:
+            - meta_scope: meta.block.go
+            - match: '(?=\})'
+              pop: true
+            - match: (?:(,)|^)\s*(\*)?(?:{{identifier}}\.)*({{identifier}})\s*(?=$|"|`)
+              captures:
+                1: punctuation.separator.go
+                2: keyword.operator.go
+                3: variable.other.member.go
+            - match: (?:(,)|^)\s*({{identifier}})
+              captures:
+                1: punctuation.separator.go
+                2: variable.other.member.go
+            - include: types
+            - include: comments
+            - include: strings
+            - include: anonymous-functions
+    - match: \b(type)\s+({{identifier}})
+      captures:
+        1: storage.type.go
+        2: entity.name.type.go
+      push:
+        - meta_scope: meta.type.go
         - match: $
-          set: pop-line-comment
+          pop: true
+        - include: comments
+        - include: types
+        - include: anonymous-functions
+        - include: keywords
+        - include: late-keywords
+    - include: expressions-late
 
-    # Line comment
-    - match: //
-      scope: punctuation.definition.comment.go
-      push: pop-line-comment
+  case-default:
+    - match: '\b(default|case)\b'
+      scope: keyword.control.go
+    - match: (,|:)
+      scope: punctuation.separator.go
 
-    # General comment
+  expressions:
+    - include: expressions-early
+    - include: expressions-late
+
+  expressions-early:
+    - include: case-default
+    - include: keywords
+
+  expressions-late:
+    - include: comments
+    - include: access
+    - include: strings
+    - include: char
+    - include: types
+    - include: anonymous-functions
+    - include: late-keywords
+    - include: operators
+    - include: function-calls
+    - include: builtins
+    - match: \[
+      scope: punctuation.definition.brackets.begin.go
+      push:
+        - meta_scope: meta.brackets.go
+        - match: \]
+          scope: punctuation.definition.brackets.end.go
+          pop: true
+        - include: expressions
+    - match: \(
+      scope: punctuation.definition.group.begin.go
+      push:
+        - meta_scope: meta.group.go
+        - match: \)
+          scope: punctuation.definition.group.end.go
+          pop: true
+        - include: expressions
+
+  builtins:
+    - match: \b(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)\b
+      scope: support.function.builtin.go
+
+  imports:
+    - match: '^\s*(import)\s+(?=")'
+      scope: meta.import.go
+      captures:
+        1: keyword.control.import.go
+      push:
+        - meta_scope: meta.import.go
+        - include: strings
+        - match: '$'
+          pop: true
+    - match: '^\s*(import)\s*(\()'
+      captures:
+        1: keyword.control.import.go
+        2: meta.group.go punctuation.definition.group.begin.go
+      push:
+        - meta_scope: meta.import.go
+        - meta_content_scope: meta.group.go
+        - match: '\)'
+          scope: meta.group.go punctuation.definition.group.end.go
+          pop: true
+        - include: comments
+        - include: strings
+
+  access:
+    - match: '(\.)({{identifier}})(?!\s*\()'
+      captures:
+        1: punctuation.accessor.go
+        2: variable.other.member.go
+
+  block:
+    - match: '\{'
+      scope: punctuation.definition.block.begin.go
+      push:
+        - meta_scope: meta.block.go
+        - match: '\}'
+          scope: punctuation.definition.block.end.go
+          pop: true
+        - include: statements
+
+  comments:
+    - match: ^/\* =(\s*.*?)\s*= \*/$\n?
+      scope: comment.block.go
+      captures:
+        1: meta.toc-list.banner.block.go
     - match: /\*
-      scope: punctuation.definition.comment.begin.go
+      scope: punctuation.definition.comment.go
       push:
         - meta_scope: comment.block.go
         - match: \*/
-          scope: punctuation.definition.comment.end.go
+          scope: punctuation.definition.comment.go
+          pop: true
+    - match: \*/
+      scope: invalid.illegal.stray-comment-end.go
+    - match: ^// =(\s*.*?)\s*=\s*$\n?
+      scope: comment.line.double-slash.banner.go
+      captures:
+        1: meta.toc-list.banner.line.go
+    - match: //
+      scope: punctuation.definition.comment.go
+      push:
+        - meta_scope: comment.line.double-slash.go
+        - match: \n
           pop: true
 
-  pop-line-comment:
-    - meta_scope: comment.line.go
-    # Including the newline allows the scope to visually stretch to the right,
-    # and ensures that functionality that relies on comment scoping, such as
-    # contextual hotkeys, works properly at EOL while typing a comment. This
-    # should also match \r\n due to Sublime's internal normalization.
-    - match: $\n?
-      pop: true
-
-  # https://golang.org/ref/spec#Tokens
-  match-tokens:
-    - include: match-keywords
-    - include: match-identifiers
-    - include: match-literals
-    - include: match-operators
-    - include: match-punctuation
-
-  # https://golang.org/ref/spec#Keywords
-  match-keywords:
-    - include: match-keyword-break
-    - include: match-keyword-case
-    - include: match-keyword-chan
-    - include: match-keyword-const
-    - include: match-keyword-continue
-    - include: match-keyword-default
-    - include: match-keyword-defer
-    - include: match-keyword-else
-    - include: match-keyword-fallthrough
-    - include: match-keyword-for
-    - include: match-keyword-func
-    - include: match-keyword-go
-    - include: match-keyword-goto
-    - include: match-keyword-if
-    - include: match-keyword-import
-    - include: match-keyword-interface
-    - include: match-keyword-map
-    - include: match-keyword-package
-    - include: match-keyword-range
-    - include: match-keyword-return
-    - include: match-keyword-select
-    - include: match-keyword-struct
-    - include: match-keyword-switch
-    - include: match-keyword-type
-    - include: match-keyword-var
-
-  # See `match-selector` for field scoping.
-  match-identifiers:
-    - include: match-predeclared-constants
-    - include: match-call-or-cast
-    - include: match-short-variable-declarations
-    - match: \b_\b
-      scope: variable.language.blank.go
-    - match: '{{ident}}'
-      scope: variable.other.go
-
-  # https://golang.org/ref/spec#Predeclared_identifiers
-  #
-  # In Go, the predeclared constants are not keywords, and can be redefined. In
-  # many places such as variable declarations, types, function names, etc, we
-  # allow them to be scoped the same way as other identifiers. This "constant"
-  # rule should be used in places that are "left over". Detecting redefinition
-  # would be ideal, but is beyond the scope of this syntax engine; we simply
-  # expect it to be very rare.
-  match-predeclared-constants:
-    - match: \b(?:true|false|nil)\b
-      scope: constant.language.go
-
-  # Note: in Go, calls and casts are syntactically identical. Detecting casts
-  # and scoping them as types is beyond the capabilities of this syntax engine.
-  #
-  # https://golang.org/ref/spec#Predeclared_identifiers
-  #
-  # Notes on built-in functions
-  #
-  # Most built-in functions don't need special syntactic support. We scope them
-  # for the benefit of the users who prefer to distinguish them from
-  # user-defined identifiers. Two exceptions are `make` and `new`, where the
-  # first argument is scoped as a type, matching the special-case support in
-  # the compiler. When built-ins are redefined, this leads to incorrect
-  # scoping; like with constants, we expect such redefinition to be very rare.
-  #
-  # Note that we limit this detection to plain function calls, ignoring method
-  # calls and other identifier occurrences. The language currently allows
-  # built-in functions ONLY in a function call position. This helps minimize
-  # false positives.
-  #
-  # Notes on built-in types
-  #
-  # Unlike casts involving a user-defined type, casts involving a built-in
-  # types could be scoped purely as types rather than function calls. However,
-  # we stick to `variable.function.go` to make the treatment of built-ins
-  # purely additive, allowing the user to opt out.
-  match-call-or-cast:
-    - match: \b(?:make|new)\b(?=(?:{{noise}}\))*{{noise}}\()
-      scope: variable.function.go support.function.builtin.go
-      push: pop-arguments-starting-with-type
-    - match: '{{predeclared_type}}(?=(?:{{noise}}\))*{{noise}}\()'
-      scope: variable.function.go support.type.builtin.go
-    - match: '{{predeclared_func}}(?=(?:{{noise}}\))*{{noise}}\()'
-      scope: variable.function.go support.function.builtin.go
-    - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
-      scope: variable.function.go
-
-  # See notes on `match-call-or-cast`.
-  pop-call-or-cast:
-    - match: \b(?:make|new)\b(?=(?:{{noise}}\))*{{noise}}\()
-      scope: variable.function.go support.function.builtin.go
-      set: pop-arguments-starting-with-type
-    - match: '{{predeclared_type}}(?=(?:{{noise}}\))*{{noise}}\()'
-      scope: variable.function.go support.type.builtin.go
-      pop: true
-    - match: '{{predeclared_func}}(?=(?:{{noise}}\))*{{noise}}\()'
-      scope: variable.function.go support.function.builtin.go
-      pop: true
-    - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
-      scope: variable.function.go
-      pop: true
-
-  # Note: this currently doesn't work across multiple lines.
-  match-short-variable-declarations:
-    - match: (?={{ident}}(?:{{noise}},{{noise}}{{ident}})*{{noise}}:=)
+  function-calls:
+    - match: (\.)({{identifier}})\s*(\()
+      captures:
+        1: punctuation.accessor.go
+        2: variable.function.go
+        3: meta.group.go punctuation.definition.group.begin.go
       push:
-        - include: match-comments
-        - match: \b_\b
-          scope: variable.language.blank.go
-        - match: '{{ident}}'
-          scope: variable.declaration.go
-        - include: match-comma
-        - include: pop-before-nonblank
-
-  # https://golang.org/ref/spec#Operators_and_punctuation
-  match-operators: [
-    {match: \!=  , scope: keyword.operator.go},
-    {match: \!   , scope: keyword.operator.go},
-    {match: \%=  , scope: keyword.operator.assignment.go},
-    {match: \%   , scope: keyword.operator.go},
-    {match: \&&  , scope: keyword.operator.go},
-    {match: \&=  , scope: keyword.operator.assignment.go},
-    {match: \&^= , scope: keyword.operator.assignment.go},
-    {match: \&^  , scope: keyword.operator.go},
-    {match: \&   , scope: keyword.operator.go},
-    {match: \*=  , scope: keyword.operator.assignment.go},
-    {match: \*   , scope: keyword.operator.go},
-    {match: \+\+ , scope: keyword.operator.go},
-    {match: \+=  , scope: keyword.operator.assignment.go},
-    {match: \+   , scope: keyword.operator.go},
-    {match: --   , scope: keyword.operator.assignment.go},
-    {match: -=   , scope: keyword.operator.assignment.go},
-    {match: \-   , scope: keyword.operator.go},
-    {match: /=   , scope: keyword.operator.assignment.go},
-    {match: /    , scope: keyword.operator.go},
-    {match: :=   , scope: keyword.operator.assignment.go},
-    {match: <-   , scope: keyword.operator.go},
-    {match: <    , scope: keyword.operator.go},
-    {match: <<=  , scope: keyword.operator.assignment.go},
-    {match: \<<  , scope: keyword.operator.go},
-    {match: <=   , scope: keyword.operator.go},
-    {match: ==   , scope: keyword.operator.go},
-    {match: \=   , scope: keyword.operator.assignment.go},
-    {match: \>=  , scope: keyword.operator.assignment.go},
-    {match: \>>= , scope: keyword.operator.assignment.go},
-    {match: \>>  , scope: keyword.operator.go},
-    {match: \>   , scope: keyword.operator.go},
-    {match: \^=  , scope: keyword.operator.assignment.go},
-    {match: \^   , scope: keyword.operator.go},
-    {match: \|=  , scope: keyword.operator.assignment.go},
-    {match: \|\| , scope: keyword.operator.go},
-    {match: \|   , scope: keyword.operator.go},
-  ]
-
-  match-star:
-    - match: \*
-      scope: keyword.operator.go
-
-  # https://golang.org/ref/spec#Operators_and_punctuation
-  match-punctuation:
-    - include: match-comma
-    - include: match-ellipsis
-    - include: match-colon
-    - include: match-semicolon
-    - include: match-selector
-    - include: match-parens
-    - include: match-brackets
-    - include: match-braces
-
-  match-comma:
-    - match: \,
-      scope: punctuation.separator.go
-
-  match-ellipsis:
-    - match: \.\.\.
-      scope: keyword.operator.variadic.go
-
-  match-colon:
-    - match: ':'
-      scope: punctuation.separator.go
-
-  match-semicolon:
-    - match: ;
-      scope: punctuation.terminator.go
-
-  match-selector:
-    - match: \.
-      scope: punctuation.accessor.dot.go
-      push:
-        - include: match-comments
-        - include: pop-type-assertion
-
-        # Note: calls and casts are syntactically identical.
-        - match: '{{ident}}(?=(?:{{noise}}\))*{{noise}}\()'
-          scope: variable.function.go
-          pop: true
-
-        - include: pop-member
-        # Note: newlines between dot and assertion/field are ok
-        - include: pop-before-nonblank
-
-  match-parens:
-    - match: \(
-      scope: punctuation.section.parens.begin.go
-      push:
+        - meta_scope: meta.function-call.method.go
+        - meta_content_scope: meta.group.go
         - match: \)
-          scope: punctuation.section.parens.end.go
+          scope: meta.group.go punctuation.definition.group.end.go
           pop: true
-        - include: pop-call-or-cast
-        - include: match-any
-    - match: \)
-      scope: punctuation.section.parens.end.go
-
-  match-brackets:
-    - match: \[
-      scope: punctuation.section.brackets.begin.go
-    - match: \]
-      scope: punctuation.section.brackets.end.go
+        - include: expressions
+    - match: (?={{identifier}}\s*\()
       push:
-        - include: pop-on-terminator
-        - include: match-comments
-        - include: match-star
-        - match: '{{ident}}(?={{noise}}\.)'
-          scope: variable.other.go
-        - match: \b_\b
-          scope: variable.language.blank.go
-          pop: true
-        - include: pop-type-identifier
-        - include: pop-before-nonblank
+        - meta_content_scope: meta.function-call.go
+        - include: builtins
+        - match: '{{identifier}}'
+          scope: variable.function.go
+        - match: '\('
+          scope: meta.group.go punctuation.definition.group.begin.go
+          set:
+            - meta_scope: meta.function-call.go
+            - meta_content_scope: meta.group.go
+            - match: \)
+              scope: meta.group.go punctuation.definition.group.end.go
+              pop: true
+            - include: expressions
 
-  match-braces:
-    - match: \{
-      scope: punctuation.section.braces.begin.go
+  initializers:
+    # Match multiple variable declarations inside of parens
+    - match: \b(var)\s+(\()
+      captures:
+        1: storage.type.go
+        2: meta.group.go punctuation.definition.group.begin.go
       push:
-        - meta_scope: meta.block.go
-        - match: \}
-          scope: punctuation.section.braces.end.go
+        - meta_scope: meta.initialization.multiple.go
+        - meta_content_scope: meta.group.go
+        - match: \)
+          scope: meta.group.go punctuation.definition.group.end.go
           pop: true
-        - include: match-any
-    - match: \}
-      scope: punctuation.section.braces.end.go
-
-  match-literals:
-    - include: match-imaginary
-    - include: match-floats
-    - include: match-integers
-    - include: match-runes
-    - include: match-strings
-
-  match-imaginary:
-    # Mandatory integer, optional fraction, optional exponent, mandatory imaginary
-    - match: \d+(?:(\.)\d+)?(?:({{exponent}})\d+)?(i)
-      scope: constant.numeric.imaginary.go
+        - match: '^\s*({{identifier}})'
+          captures:
+            1: variable.other.go
+          push:
+            - match: '\s*(,)\s*({{identifier}})'
+              captures:
+                1: punctuation.separator.go
+                2: variable.other.go
+            - match: ''
+              pop: true
+        - include: expressions
+    # Match multiple constant declarations inside of parens
+    - match: \b(const)\s+(\()
       captures:
-        1: punctuation.separator.decimal.go
-        2: punctuation.separator.exponent.go
-        3: storage.type.numeric.imaginary.go
-    # Dot without fraction
-    - match: \d+\.(?:{{exponent}}\d+)?i
-      scope: invalid.deprecated.go
-    # Dot without integer
-    - match: \.\d+(?:{{exponent}}\d+)?i
-      scope: invalid.deprecated.go
-
-  match-floats:
-    # Integer, no fraction, exponent
-    - match: \d+({{exponent}})\d+
-      scope: constant.numeric.float.go
+        1: storage.type.go
+        2: meta.group.go punctuation.definition.group.begin.go
+      push:
+        - meta_content_scope: meta.group.go
+        - match: \)
+          scope: meta.group.go punctuation.definition.group.end.go
+          pop: true
+        - match: '^\s*({{identifier}})'
+          captures:
+            1: entity.name.constant.go
+          push:
+            - match: '\s*(,)\s*({{identifier}})'
+              captures:
+                1: punctuation.separator.go
+                2: entity.name.constant.go
+            - match: ''
+              pop: true
+        - include: expressions
+    # Match a single constant
+    - match: \b(const)b(?:\s+({{identifier}}))?
       captures:
-        1: punctuation.separator.exponent.go
-    # Integer, fraction, optional exponent
-    - match: \d+(\.)\d+(?:({{exponent}})\d+)?
-      scope: constant.numeric.float.go
+        1: storage.type.go
+        2: entity.name.constant.go
+    # Matches the 'var x int = 0' style of variable declaration
+    - match: '^\s*(var)\s+({{identifier}})'
       captures:
-        1: punctuation.separator.decimal.go
-        2: punctuation.separator.exponent.go
-    # Dot without fraction
-    - match: \d+\.(?:{{exponent}}\d+)?
-      scope: invalid.deprecated.go
-    # Dot without integer
-    - match: \.\d+(?:{{exponent}}\d+)?
-      scope: invalid.deprecated.go
+        1: storage.type.go
+        2: variable.other.go
+      push:
+        - meta_scope: meta.initialization.explicit.go
+        - include: comments
+        - match: '\s*(,)\s*({{identifier}})'
+          captures:
+            1: punctuation.separator.go
+            2: variable.other.go
+        - match: ''
+          set:
+            - meta_content_scope: meta.initialization.explicit.go
+            - match: '$'
+              pop: true
+            - include: expressions
+    # Matches the 'x := 0' style of variable declaration
+    - match: '({{identifier}})(?=(\s*,\s*{{identifier}})*\s*:=)'
+      scope: variable.other.go
+      push:
+        - meta_scope: meta.initialization.short.go
+        - include: comments
+        - match: '\s*(,)\s*({{identifier}})'
+          captures:
+            1: punctuation.separator.go
+            2: variable.other.go
+        - match: ':='
+          scope: keyword.operator.initialize.go
+          pop: true
 
-  match-integers:
-    - include: match-octal-integer
-    - include: match-hex-integer
-    - include: match-decimal-integer
-
-  match-octal-integer:
-    - match: (0)[0-7]+(?=\D)
-      scope: constant.numeric.octal.go
-      captures:
-        1: punctuation.definition.numeric.octal.go
-    - match: 0[0-7]*[8-9]+
-      scope: invalid.illegal.go
-
-  match-hex-integer:
-    - match: (0[Xx])\h+
-      scope: constant.numeric.hex.go
+  keywords:
+    - match: \b(s(elect|witch)|c(ontinue|ase)|i(f|mport)|def(er|ault)|package|else|f(or|allthrough)|r(eturn|ange)|go(to)?|break)\b
+      scope: keyword.control.go
+    - match: \b(nil|true|false|iota)\b
+      scope: constant.language.go
+    - match: '\b(0[xX])\h*\b'
+      scope: constant.numeric.integer.hexadecimal.go
       captures:
         1: punctuation.definition.numeric.hexadecimal.go
+    - match: '\b([0-9]+\.[0-9]*|\.[0-9]+)([eE][+-]?\d+)?\b'
+      scope: constant.numeric.float.decimal.go
+    - match: '\b\d+\b'
+      scope: constant.numeric.integer.decimal.go
 
-  match-decimal-integer:
-    - match: \d+
-      scope: constant.numeric.integer.go
+  late-keywords:
+    - match: \b(chan|func|var|type|map)\b
+      scope: storage.type.go
+    - match: \bconst\b
+      scope: storage.modifier.go
 
-  # https://golang.org/ref/spec#Rune_literals
-  match-runes:
-    - match: \'({{char_escape}})'
-      scope: constant.character.go
+  operators:
+    - match: '\|\|'
+      scope: keyword.operator.go
+    - match: '&[&^]'
+      scope: keyword.operator.go
+    - match: ':='
+      scope: keyword.operator.initialize.go
+    - match: '[=!<>]='
+      scope: keyword.operator.go
+    - match: <<|>>
+      scope: keyword.operator.go
+    - match: <-|->
+      scope: keyword.operator.channel.go
+    - match: '='
+      scope: keyword.operator.assignment.go
+    - match: '[-/*&<>+|^%!]'
+      scope: keyword.operator.go
+
+  types:
+    - match: '\b(struct|interface)\b(?:(\{)(\}))?'
       captures:
-        1: constant.character.escape.go
-    - match: \'[^']*'
-      scope: constant.character.go
-
-  match-strings:
-    - include: match-raw-string
-    - include: match-interpreted-string
-
-  match-raw-string:
-    - match: '`'
-      scope: punctuation.definition.string.begin.go
+        1: storage.type.go
+        2: meta.block.go punctuation.definition.block.begin.go
+        3: meta.block.go punctuation.definition.block.end.go
+    - match: (\[)(\d*)(\])(?=[[:alpha:]_])
+      scope: meta.brackets.go
+      captures:
+        1: punctuation.definition.brackets.begin.go
+        2: constant.numeric.go
+        3: punctuation.definition.brackets.end.go
+    - match: '\b(map)\b(\[)'
+      captures:
+        1: storage.type.go
+        2: meta.brackets.go punctuation.definition.brackets.begin.go
       push:
-        - meta_scope: string.quoted.other.go
-        - match: '`'
-          scope: punctuation.definition.string.end.go
+        - meta_content_scope: meta.brackets.go
+        - match: '(?=\s|$)'
           pop: true
-        - match: \%%
-          scope: constant.character.escape.go
-        - include: match-fmt
+        - match: \]
+          scope: meta.brackets.go punctuation.definition.brackets.end.go
+          pop: true
+        - include: types
+    - match: '(<-)?\b(chan)\b(<-)?(?=\s+[[:alpha:]_])'
+      captures:
+        1: keyword.operator.channel.go
+        2: storage.type.go
+        3: keyword.operator.channel.go
+    - include: basic-types
 
-  match-interpreted-string:
+  basic-types:
+    - match: '\b(int(16|8|32|64)?|uint(16|8|32|ptr|64)?|float(32|64)?|b(yte|ool)|error|string|rune|complex(64|128))\b'
+      scope: storage.type.go
+    - match: '\b(ComplexType|FloatType|IntegerType|Type|Type1)\b'
+      scope: storage.type.go
+
+  functions:
+    - include: reciever-function-begin
+    - include: plain-function-begin
+    - include: anonymous-functions
+    - match: '\b(func)\s+({{identifier}})'
+      captures:
+        1: storage.type.go
+        2: entity.name.function.go
+
+  anonymous-functions:
+    - include: no-param-anonymous-function-begin
+    - include: multi-param-anonymous-function-begin
+    - include: single-param-anonymous-function-begin
+
+  reciever-function-begin:
+    - match: |-
+        (?x)
+        (func)
+        \s*
+        # receiver declaration: (Type), (*Type), (t Type), (t *Type)
+        (
+          (\()
+            (?:\s*({{identifier}})\s+)?
+            (\*?)
+            \s*
+            {{identifier}}
+            \s*
+          (\))
+        )
+        \s*
+        # name of function
+        ( {{identifier}} )
+        (?=\s*\()
+      scope: meta.function.declaration.go
+      captures:
+        1: storage.type.go
+        2: meta.group.go
+        3: punctuation.definition.group.begin.go
+        4: variable.parameter.receiver.go
+        5: keyword.operator.go
+        6: punctuation.definition.group.end.go
+        7: entity.name.function.go
+      push: function-params
+
+  plain-function-begin:
+    - match: |-
+        (?x)
+        (func)
+        \s*
+        # name of function
+        ( {{identifier}} )
+        (?=\s*\()
+      scope: meta.function.declaration.go
+      captures:
+        1: storage.type.go
+        2: entity.name.function.go
+      push: function-params
+
+  no-param-anonymous-function-begin:
+    - match: |-
+        (?x)
+        (func)
+        (\s*)
+        ((\()\s*(\)))
+        (\s*)
+      captures:
+        1: meta.function.declaration.anonymous.go storage.type.go
+        2: meta.function.go
+        3: meta.function.parameters.go meta.group.go
+        4: punctuation.definition.group.begin.go
+        5: punctuation.definition.group.end.go
+        6: meta.function.go
+      push: function-return-type
+
+  multi-param-anonymous-function-begin:
+    - match: |-
+        (?x)
+        (func)
+        (\s*)
+        # param list with at least one comma: (t Type, ...)
+        (?=\(.*,)
+      scope: meta.function.declaration.anonymous.go
+      captures:
+        1: meta.function.declaration.anonymous.go storage.type.go
+        2: meta.function.go
+      push: function-params
+
+  single-param-anonymous-function-begin:
+    - match: |-
+        (?x)
+        (func)
+        (\s*)
+        (?=
+          # single param: (t Type)
+          \([^,)]+\)
+          \s*
+          # return type: Type, (Type), (Type, Type2)
+          (
+            \({{type_chars}}+\)
+            |
+            {{type_chars}}
+          )?
+          \s*
+          (\{|$)
+        )
+      captures:
+        1: meta.function.declaration.anonymous.go storage.type.go
+        2: meta.function.go
+      push: function-params
+
+  function-params:
+    - match: (\s*)(\()(\s*)
+      captures:
+        1: meta.function.go
+        2: meta.function.parameters.go meta.group.go punctuation.definition.group.begin.go
+        3: meta.function.parameters.go meta.group.go
+      # Create a temporary context to handle the initial parameter if it does
+      # not include a type
+      set: function-params-param-name
+
+  function-params-param-name:
+    # If the first thing is an identifier followed by a comma or a comment
+    # and then a comma, it is a parameter that shares a type with a later
+    # parameter
+    - meta_content_scope: meta.function.parameters.go meta.group.go
+    - match: \s+(?=/\*)
+    - include: comments
+    - match: '\s*({{identifier}})(?=\s*,|\s*/\*.*?\*/\s*,)'
+      captures:
+        1: variable.parameter.go
+      set: function-params-other
+    - match: ''
+      set: function-params-other
+
+  function-params-other:
+    - meta_content_scope: meta.function.parameters.go meta.group.go
+    - match: (?=\)\s*)
+      set:
+        - match: '(\))(\s*)'
+          captures:
+            1: meta.function.parameters.go meta.group.go punctuation.definition.group.end.go
+            2: meta.function.go
+          set: function-return-type
+    - include: comments
+    - match: '{{identifier}}(?=\s+[^\s,)])'
+      scope: variable.parameter.go
+      set:
+        - meta_content_scope: meta.function.parameters.go meta.group.go
+        - match: '(?=\))'
+          set: function-params-other
+        - match: '(,)\s*'
+          captures:
+            1: punctuation.separator.go
+          set: function-params-param-name
+        - include: types-group
+    - include: types-group
+    - match: ','
+      scope: punctuation.separator.go
+
+  function-return-type:
+    - meta_content_scope: meta.function.return-type.go
+    - match: '(?=\{)'
+      set: function-body
+    - include: types-group
+    # Match an identifier so that is doesn't trigger an exit from the context
+    - match: '{{identifier}}'
+    - match: \(
+      scope: meta.group.go punctuation.definition.group.begin.go
+      set:
+        - meta_content_scope: meta.function.return-type.go meta.group.go
+        - match: '\)'
+          scope: punctuation.definition.group.end.go
+          set: function-body
+        - match: ','
+          scope: punctuation.separator.go
+        - include: types-group
+    # If a function declaration ends in a newline not in parens and not in a
+    # block, it is a forward declaration
+    - match: $
+      pop: true
+    # Exit for any other char, such as )
+    - match: (?=\S)
+      pop: true
+
+  types-group:
+    - include: comments
+    - match: \*
+      scope: keyword.operator.go
+    - include: types
+
+  function-body:
+    - match: $
+      pop: true
+    - match: (\s*)(\{)
+      captures:
+        1: meta.function.go
+        2: meta.function.go meta.block.go punctuation.definition.block.begin.go
+      set:
+        - meta_content_scope: meta.function.go meta.block.go
+        - match: \}
+          scope: meta.function.go meta.block.go punctuation.definition.block.end.go
+          pop: true
+        - include: statements
+
+  string-escaped-char:
+    - match: '\\(\\|[abfnrutv''"]|x\h{2}|u\h{4}|U\h{8}|[0-7]{3})'
+      scope: constant.character.escape.go
+    - match: \\.
+      scope: invalid.illegal.unknown-escape.go
+
+  string-placeholder:
+    - match: |-
+        (?x)%
+            [#0\- +']*                                  # flags
+            (\[\d+\])?                                  # field (argument #)
+            [,;:_]?                                     # separator character (AltiVec)
+            ((-?\d+)|(\[\d+\])?\*)?                     # minimum field width
+            (\.((-?\d+)|(\[\d+\])?\*)?)?                # precision
+            [diouxXDOUeEfFgGaAcCsSpqnvtTbyYhHmMzZ%]     # conversion type
+      scope: constant.other.placeholder.go
+    - match: "%"
+      scope: invalid.illegal.placeholder.go
+
+  strings:
     - match: '"'
       scope: punctuation.definition.string.begin.go
       push:
@@ -489,643 +598,22 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.go
           pop: true
-        - match: '{{char_escape}}'
-          scope: constant.character.escape.go
-        - match: \%%
-          scope: constant.character.escape.go
-        - include: match-fmt
-
-  # https://godoc.org/fmt
-  #
-  # Tries to match known patterns without being too specific. We want to avoid
-  # false positives in non-fmt strings that just happen to contain %, but don't
-  # want too much coupling with the current version of fmt.
-  match-fmt:
-    - match: '\%(?:\[\d+\])?[ .\d#+-]*[A-Za-z]'
-      scope: constant.other.placeholder.go
-
-  match-keyword-break:
-    - match: \bbreak\b
-      scope: keyword.control.go
-
-  match-keyword-case:
-    - match: \bcase\b
-      scope: keyword.control.go
-
-  match-keyword-chan:
-    - match: (?=\bchan\b)
-      push: pop-chan
-
-  match-keyword-const:
-    - match: \bconst\b
-      scope: storage.type.keyword.const.go
+        - include: string-placeholder
+        - include: string-escaped-char
+    - match: "`"
+      scope: punctuation.definition.string.begin.go
       push:
-        - match: \(
-          scope: punctuation.section.parens.begin.go
-          set:
-            - match: \)
-              scope: punctuation.section.parens.end.go
-              pop: true
-
-            - match: \b_\b(?={{noise}},)
-              scope: variable.language.blank.go
-            - match: '{{ident}}(?={{noise}},)'
-              scope: variable.other.constant.declaration.go
-
-            - match: \b_\b
-              scope: variable.language.blank.go
-              push: pop-const-type-and-or-assignment
-            - match: '{{ident}}'
-              scope: variable.other.constant.declaration.go
-              push: pop-const-type-and-or-assignment
-
-            - include: match-any
-
-        - include: match-comments
-        - include: match-comma
-
-        - match: \b_\b(?={{noise}},)
-          scope: variable.language.blank.go
-        - match: '{{ident}}(?={{noise}},)'
-          scope: variable.other.constant.declaration.go
-
-        - match: \b_\b
-          scope: variable.language.blank.go
-          set: pop-const-type-and-or-assignment
-        - match: '{{ident}}'
-          scope: variable.other.constant.declaration.go
-          set: pop-const-type-and-or-assignment
-
-        - include: pop-before-nonblank
-
-  match-keyword-continue:
-    - match: \bcontinue\b
-      scope: keyword.control.go
-
-  match-keyword-default:
-    - match: \bdefault\b
-      scope: keyword.control.go
-
-  match-keyword-defer:
-    - match: \bdefer\b
-      scope: keyword.control.go
-
-  match-keyword-else:
-    - match: \belse\b
-      scope: keyword.control.go
-
-  match-keyword-fallthrough:
-    - match: \bfallthrough\b
-      scope: keyword.control.go
-
-  match-keyword-for:
-    - match: \bfor\b
-      scope: keyword.control.go
-
-  match-keyword-func:
-    - match: \bfunc\b
-      scope: storage.type.keyword.function.go
-      push:
-        - include: match-comments
-
-        # Method
-        - match: (?=\({{noise}}[^)]+{{noise}}\){{noise}}{{ident}}{{noise}}\()
-          set:
-            - meta_scope: meta.function.declaration.go
-            - match: (?=[^(])
-              set:
-                - meta_scope: meta.function.declaration.go
-                - include: pop-func-signature
-            # Receiver list
-            - match: (?=\()
-              push: pop-func-parameter-list
-
-        # Named function
-        - match: (?={{ident}}{{noise}}\()
-          set: pop-func-signature
-
-        # Anonymous function
-        - include: pop-func-parameter-and-return-lists
-
-  match-keyword-go:
-    - match: \bgo\b
-      scope: keyword.control.go
-
-  match-keyword-goto:
-    - match: \bgoto\b
-      scope: keyword.control.go
-
-  match-keyword-if:
-    - match: \bif\b
-      scope: keyword.control.go
-
-  match-keyword-import:
-    - match: \bimport\b
-      scope: keyword.other.import.go
-
-  match-keyword-interface:
-    - match: (?=\binterface\b)
-      scope: storage.type.keyword.interface.go
-      push: pop-interface
-
-  match-keyword-map:
-    - match: (?=\bmap\b)
-      push: pop-map
-
-  match-keyword-package:
-    - match: \bpackage\b
-      scope: keyword.other.package.go
-
-  match-keyword-range:
-    - match: \brange\b
-      scope: keyword.other.go
-
-  match-keyword-return:
-    - match: \breturn\b
-      scope: keyword.control.go
-
-  match-keyword-select:
-    - match: \bselect\b
-      scope: keyword.control.go
-
-  match-keyword-struct:
-    - match: (?=\bstruct\b)
-      push: pop-struct
-
-  match-keyword-switch:
-    - match: \bswitch\b
-      scope: keyword.control.go
-
-  match-keyword-type:
-    - match: \btype\b
-      scope: storage.type.keyword.type.go
-      push:
-        - include: match-comments
-
-        - match: \(
-          scope: punctuation.section.parens.begin.go
-          set:
-            - match: \)
-              scope: punctuation.section.parens.end.go
-              pop: true
-            - match: \b_\b
-              scope: variable.language.blank.go
-              push:
-                - match: (?=\))
-                  pop: true
-                - include: pop-type-alias-or-typedef
-            - match: '{{ident}}'
-              scope: entity.name.type.go
-              push:
-                - match: (?=\))
-                  pop: true
-                - include: pop-type-alias-or-typedef
-            - include: match-any
-
-        - match: \b_\b
-          scope: variable.language.blank.go
-          set: pop-type-alias-or-typedef
-        - match: '{{ident}}'
-          scope: entity.name.type.go
-          set: pop-type-alias-or-typedef
-
-        - include: pop-before-nonblank
-
-  match-keyword-var:
-    - match: \bvar\b
-      scope: storage.type.keyword.var.go
-      push:
-        - match: \(
-          scope: punctuation.section.parens.begin.go
-          set:
-            - match: \)
-              scope: punctuation.section.parens.end.go
-              pop: true
-
-            - match: \b_\b(?={{noise}},)
-              scope: variable.language.blank.go
-            - match: '{{ident}}(?={{noise}},)'
-              scope: variable.declaration.go
-
-            - match: \b_\b
-              scope: variable.language.blank.go
-              push: pop-var-type-and-or-assignment
-            - match: '{{ident}}'
-              scope: variable.declaration.go
-              push: pop-var-type-and-or-assignment
-
-            - include: match-any
-
-        - include: match-comments
-        - include: match-comma
-
-        - match: \b_\b(?={{noise}},)
-          scope: variable.language.blank.go
-        - match: '{{ident}}(?={{noise}},)'
-          scope: variable.declaration.go
-
-        - match: \b_\b
-          scope: variable.language.blank.go
-          set: pop-var-type-and-or-assignment
-        - match: '{{ident}}'
-          scope: variable.declaration.go
-          set: pop-var-type-and-or-assignment
-
-        - include: pop-before-nonblank
-
-  pop-func-signature:
-    - include: match-comments
-    - match: \b_\b
-      scope: variable.language.blank.go
-      set: pop-func-parameter-and-return-lists
-    - match: '{{ident}}'
-      scope: entity.name.function.go
-      set: pop-func-parameter-and-return-lists
-    - include: pop-before-nonblank
-
-  # https://golang.org/ref/spec#Function_types
-  #
-  # Go has two parameter syntaxes: unnamed and named.
-  #
-  # Unnamed:
-  #
-  #   (int)
-  #   (int, int)
-  #   (int, int, ...int)
-  #
-  # Named:
-  #
-  #   (a int)
-  #   (a, b int)
-  #   (a, b ...int)
-  #   (a int, b int)
-  #   (a, b int, c ...int)
-  #
-  # The modes are distinct: either all named, or all unnamed.
-  #
-  # Gotchas:
-  #
-  #   parameters can span multiple lines
-  #   a type can span multiple lines (anonymous struct, interface, etc.)
-  #   parameter groups AND parameter names are comma-separated
-  #   `chan type` is a type that looks like an identifier followed by a type
-  #
-  # I have an impression that with the current syntax engine, it's impossible to
-  # perfectly parse some parameter lists, particularly ones that are named,
-  # multiline, and have name groups. We're still trying to cover as many edge
-  # cases as possible.
-  pop-func-parameter-and-return-lists:
-    - include: match-comments
-    - match: (?=\()
-      set: [pop-func-return-signature, pop-func-parameter-list]
-    - include: pop-before-nonblank
-
-  pop-func-return-signature:
-    - include: pop-on-terminator
-    - include: match-comments
-    - match: (?=\()
-      set: pop-func-parameter-list
-    - match: (?=\S)
-      set: pop-type
-
-  pop-func-parameter-list:
-    - include: match-comments
-    - match: \(
-      scope: punctuation.section.parens.begin.go
-      set:
-        - include: match-comments
-        - match: |
-            (?x)
-            (?=
-              (?:{{noise}}{{ident}}{{noise}},{{noise}})*
-              {{ident}}{{noise}}(?:\.\.\.|[^\s/,).])
-            )
-          set: pop-parameter-list-named
-        - match: (?=\S)
-          set: pop-parameter-list-unnamed
-    - include: pop-before-nonblank
-
-  pop-parameter-list-named:
-    - match: \)
-      scope: punctuation.section.parens.end.go
-      pop: true
-    - include: match-comments
-    - include: match-keywords
-    - include: match-comma
-    - include: match-ellipsis
-    - match: \b_\b
-      scope: variable.language.blank.go
-      push: pop-parameter-type
-    - match: '{{ident}}'
-      scope: variable.parameter.go
-      push: pop-parameter-type
-
-  pop-parameter-type:
-    - match: (?=\)|,)
-      pop: true
-    - include: match-ellipsis
-    - include: pop-type
-
-  pop-parameter-list-unnamed:
-    - match: \)
-      scope: punctuation.section.parens.end.go
-      pop: true
-    - include: match-comments
-    - include: match-keywords
-    - include: match-comma
-    - include: match-ellipsis
-    - match: (?=\S)
-      push: pop-type
-
-  pop-before-nonblank:
-    - match: (?=\S)
-      pop: true
-
-  pop-on-semicolon:
-    - match: ;
-      scope: punctuation.terminator.go
-      pop: true
-
-  pop-on-terminator:
-    - include: pop-on-semicolon
-    - match: $
-      pop: true
-
-  pop-type:
-    - include: pop-on-semicolon
-    - include: match-comments
-
-    # Note: Go allows wrapping types in an arbitrary number of parens.
-    - match: \(
-      scope: punctuation.section.parens.begin.go
-      push: [pop-type-nested-in-parens, pop-type]
-
-    - match: \[
-      scope: punctuation.section.brackets.begin.go
-      set:
-        - match: \]
-          scope: punctuation.section.brackets.end.go
-          # BUG:
-          #   _ = blah[0] * blah
-          # This currently parses as an array type of `[0]*blah`.
-          # Can we fix this false positive?
-          set: pop-type
-        - include: match-any
-
-    - include: match-operators
-
-    - match: (?=\bchan\b)
-      set: pop-chan
-    - match: (?=\binterface\b)
-      set: pop-interface
-    - match: (?=\bmap\b)
-      set: pop-map
-    - match: (?=\bstruct\b)
-      set: pop-struct
-    - match: \bfunc\b
-      scope: storage.type.keyword.function.go
-      set: pop-func-parameter-and-return-lists
-    - match: (?={{ident}})
-      set: pop-named-type
-
-    - include: pop-before-nonblank
-
-  pop-type-nested-in-parens:
-    - match: \)
-      scope: punctuation.section.parens.end.go
-      pop: true
-    - include: pop-type
-
-  pop-struct:
-    - match: \bstruct\b
-      scope: storage.type.keyword.struct.go
-      set:
-        - include: match-comments
-        - match: \{
-          scope: punctuation.section.braces.begin.go
-          set:
-            - meta_scope: meta.type.go
-
-            - match: \}
-              scope: punctuation.section.braces.end.go
-              pop: true
-
-            - include: match-keywords
-            - include: match-star
-
-            - match: '{{ident}}(?={{noise}}\.)'
-              scope: variable.other.go
-            - match: \.
-              scope: punctuation.accessor.dot.go
-            - match: '{{predeclared_type}}(?={{noise}}(?:"|`|//|;|\}|$))'
-              scope: entity.other.inherited-class.go support.type.builtin.go
-            - match: '{{ident}}(?={{noise}}(?:"|`|//|;|\}|$))'
-              scope: entity.other.inherited-class.go
-
-            - match: \b_\b
-              scope: variable.language.blank.go
-            - match: '{{ident}}'
-              scope: variable.other.member.declaration.go
-              push:
-                - match: (?=\})
-                  pop: true
-                - include: pop-on-terminator
-                - include: match-comments
-                - include: pop-type
-                - include: match-any
-
-            - include: match-any
-
-        - include: pop-before-nonblank
-
-  pop-interface:
-    - match: \binterface\b
-      scope: storage.type.keyword.interface.go
-      set:
-        - include: match-comments
-        - match: \{
-          scope: punctuation.section.braces.begin.go
-          set:
-            - meta_scope: meta.type.go
-            - match: \}
-              scope: punctuation.section.braces.end.go
-              pop: true
-
-            - include: match-keywords
-            - include: match-star
-
-            - match: '{{ident}}(?={{noise}}\.)'
-              scope: variable.other.go
-            - match: \.
-              scope: punctuation.accessor.dot.go
-            - match: '{{predeclared_type}}(?={{noise}}(?://|;|\}|$))'
-              scope: entity.other.inherited-class.go support.type.builtin.go
-            - match: '{{ident}}(?={{noise}}(?://|;|\}|$))'
-              scope: entity.other.inherited-class.go
-
-            - match: '{{ident}}(?={{noise}}\()'
-              scope: entity.name.function.go
-              push:
-                - match: (?=\})
-                  pop: true
-                - include: pop-func-parameter-and-return-lists
-
-            - include: match-any
-        - include: pop-before-nonblank
-
-  pop-map:
-    # Note: newlines between `map` and `[` are ok, but newlines after `]`
-    # terminate the type.
-    - match: \bmap\b
-      scope: storage.type.keyword.map.go
-      set:
-        - include: match-comments
-        - include: pop-on-semicolon
-        - match: \[
-          scope: punctuation.section.brackets.begin.go
-          set:
-            - match: \]
-              scope: punctuation.section.brackets.end.go
-              set:
-                - include: pop-on-terminator
-                - include: pop-type
-            - include: match-comments
-            - match: (?=\S)
-              push:
-                - match: (?=\])
-                  pop: true
-                - include: pop-type
-        - include: pop-type
-
-  # Note: newlines between `chan`, subsequent arrow, and subsequent type, are
-  # perfectly ok.
-  pop-chan:
-    - match: \bchan\b
-      scope: storage.type.keyword.chan.go
-      set: pop-type
-
-  pop-named-type:
-    - include: match-comments
-    - match: \b_\b
-      scope: variable.language.blank.go
-      pop: true
-    - match: '{{ident}}(?={{noise}}\.)'
-      scope: variable.other.go
-    - match: \.
-      scope: punctuation.accessor.dot.go
-    - match: \b_\b
-      scope: variable.language.blank.go
-      pop: true
-    - include: pop-type-identifier
-    - include: pop-before-nonblank
-
-  pop-type-identifier:
-    - match: '{{predeclared_type}}'
-      scope: storage.type.go support.type.builtin.go
-      pop: true
-    - match: '{{ident}}'
-      scope: storage.type.go
-      pop: true
-
-  pop-type-alias-or-typedef:
-    - include: pop-on-terminator
-    - include: match-comments
-    # Newlines after `=` are ok.
-    - match: =
-      scope: keyword.operator.assignment.go
-      set: pop-type
-    - match: (?=\S)
-      set: pop-type
-
-  pop-const-type-and-or-assignment:
-    - include: pop-on-terminator
-    - include: match-comments
-    - match: =
-      scope: keyword.operator.assignment.go
-      set: pop-const-expressions
-    - match: (?=\S)
-      set: [pop-const-assignment-or-terminate, pop-type]
-
-  pop-const-assignment-or-terminate:
-    - include: pop-on-terminator
-    - include: match-comments
-    - match: =
-      scope: keyword.operator.assignment.go
-      set: pop-const-expressions
-    - include: pop-before-nonblank
-
-  # Note: this doesn't support multiline expressions.
-  #
-  # Note on `iota`. See https://golang.org/ref/spec#Iota. `iota` is a regular
-  # identifier that happens to be predeclared in constant initialization
-  # expressions, but not anywhere else. Just like `true|false|nil`, you can
-  # redefine it. Doing so in the root scope makes the magic constant unavailable
-  # for the entire package.
-  pop-const-expressions:
-    - include: pop-on-semicolon
-    - include: match-comments
-    - match: (?=\S)
-      set:
-        - include: pop-on-terminator
-        - match: \biota\b
-          scope: constant.numeric.integer.go
-        - include: match-any
-
-  pop-var-type-and-or-assignment:
-    - include: pop-on-terminator
-    - include: match-comments
-    - match: =
-      scope: keyword.operator.assignment.go
-      set: pop-var-expressions
-    - match: (?=\S)
-      set: [pop-var-assignment-or-terminate, pop-type]
-
-  pop-var-assignment-or-terminate:
-    - include: pop-on-terminator
-    - include: match-comments
-    - match: =
-      scope: keyword.operator.assignment.go
-      set: pop-var-expressions
-    - include: pop-before-nonblank
-
-  # Note: this doesn't support multiline expressions.
-  pop-var-expressions:
-    - include: pop-on-semicolon
-    - include: match-comments
-    - match: (?=\S)
-      set:
-        - include: pop-on-terminator
-        - include: match-any
-
-  pop-type-assertion:
-    - match: \(
-      scope: punctuation.section.parens.begin.go
-      set:
-        - match: \)
-          scope: punctuation.section.parens.end.go
+        - meta_scope: string.quoted.raw.go
+        - match: "`"
+          scope: punctuation.definition.string.end.go
           pop: true
-        - include: pop-type
-
-  pop-member:
-    - match: \b_\b
-      scope: variable.language.blank.go
-      pop: true
-    - match: '{{ident}}'
-      scope: variable.other.member.go
-      pop: true
-
-  pop-arguments-starting-with-type:
-    - include: match-comments
-    - match: \)
-      scope: punctuation.section.parens.end.go
-    - match: \(
-      scope: punctuation.section.parens.begin.go
-      set:
-        - match: \)
-          scope: punctuation.section.parens.end.go
+        - include: string-placeholder
+  char:
+    - match: "'"
+      scope: punctuation.definition.string.begin.go
+      push:
+        - meta_scope: string.quoted.single.go
+        - match: "'"
+          scope: punctuation.definition.string.end.go
           pop: true
-        - include: match-comments
-        - match: (?=\S)
-          set: pop-type
-    - include: pop-on-terminator
-    - include: pop-before-nonblank
+        - include: string-escaped-char

--- a/Packages/Go/syntax_test_go.go
+++ b/Packages/Go/syntax_test_go.go
@@ -1,2768 +1,311 @@
-// SYNTAX TEST "Go.sublime-syntax"
-
-/*
-NOTES
-
-This file is not intended to pass compilation or `go vet`.
-
-This file must not be formatted with `go fmt`.
-
-You may have to disable Go-specific linters when working on this file.
-*/
-
-
-// # Comments
-
-    //
-// ^ -comment -punctuation
-//  ^^ punctuation.definition.comment.go
-//  ^^^ comment.line.go
-
-    // comment // comment
-// ^ -comment -punctuation
-//  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^^^^ comment.line.go
-//             ^^ -punctuation
-
-    /* comment // comment */  // comment
-// ^ -comment -punctuation
-//  ^^ punctuation.definition.comment.begin.go
-//  ^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.go
-//             ^^ -punctuation
-//                        ^^ punctuation.definition.comment.end.go
-//                          ^^ -comment -punctuation
-//                            ^^ punctuation.definition.comment.go
-//                            ^^^^^^^^^^^ comment.line.go
-
-    /*
-// ^ -comment
-//  ^^^^ comment.block.go
-    comment
-//  ^^^^^^^^ comment.block.go
-    */
-//  ^^ comment.block.go
-//    ^ -comment
-
-    /* * */
-// ^ -comment
-//  ^^^^^^^ comment.block.go
-//         ^ -comment
-
-    //go
-// ^ -comment -punctuation
-//  ^^ punctuation.definition.comment.go
-//  ^^^^^ comment.line.go -meta.annotation
-
-    //go:
-// ^ -comment -meta -punctuation
-//  ^^ punctuation.definition.comment.go
-//  ^^^^^ comment.line.go meta.annotation.go
-//       ^ comment.line.go -meta.annotation
-
-    //go:generate one two three
-// ^ -comment -meta -punctuation
-//  ^^ punctuation.definition.comment.go
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
-//                             ^ comment.line.go -meta.annotation
-
-
-// # Imports
-
-    package main
-//  ^^^^^^^ keyword.other.package.go
-//         ^^^^^ -keyword
-
-    import "module"
-//  ^^^^^^ keyword.other.import.go
-//         ^^^^^ string.quoted.double.go
-
-    import (ident "module")
-//  ^^^^^^ keyword.other.import.go
-//         ^ punctuation.section.parens.begin.go
-//          ^^^^^ variable.other.go
-//                ^ string.quoted.double.go punctuation.definition.string.begin.go
-//                 ^^^^^^ string.quoted.double.go
-//                       ^ string.quoted.double.go punctuation.definition.string.end.go
-//                        ^ punctuation.section.parens.end.go
-
-    import (
-//  ^^^^^^ keyword.other.import.go
-        ident "module"      // comment
-//      ^^^^^ variable.other.go
-//            ^ string.quoted.double.go punctuation.definition.string.begin.go
-//             ^^^^^^ string.quoted.double.go
-//                   ^ string.quoted.double.go punctuation.definition.string.end.go
-//                          ^^^^^^^^^^^ comment.line.go
-        ident "module"      // comment
-//      ^^^^^ variable.other.go
-//            ^ string.quoted.double.go punctuation.definition.string.begin.go
-//             ^^^^^^ string.quoted.double.go
-//                   ^ string.quoted.double.go punctuation.definition.string.end.go
-//                          ^^^^^^^^^^^ comment.line.go
-    )
-
-
-// # Type Keywords and Syntax
-
-/*
-Type keywords are tested early because they're used in many other tests.
-
-Note: Go permits an arbitrary number of parens around a type.
-
-Note: built-ins are tested separately. Search for "# Built-in Types".
-*/
-
-// ## chan
-
-    chan _
-//  ^^^^ storage.type.keyword.chan.go
-//       ^ variable.language.blank.go
-
-    chan typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^ storage.type.go
-
-    chan typ ident
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^ storage.type.go
-//           ^^^^^ variable.other.go
-
-    chan ((typ))
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^ punctuation.section.parens.begin.go
-//         ^^^ storage.type.go
-//            ^^ punctuation.section.parens.end.go
-
-    chan ident.typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^^ variable.other.go
-//            ^ punctuation.accessor.dot.go
-//             ^^^ storage.type.go
-
-    chan ident.ident.typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^^ variable.other.go
-//            ^ punctuation.accessor.dot.go
-//             ^^^^^ variable.other.go
-//                  ^ punctuation.accessor.dot.go
-//                   ^^^ storage.type.go
-
-    chan ((ident.ident.typ))
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^ punctuation.section.parens.begin.go
-//         ^^^^^ variable.other.go
-//              ^ punctuation.accessor.dot.go
-//               ^^^^^ variable.other.go
-//                    ^ punctuation.accessor.dot.go
-//                     ^^^ storage.type.go
-//                        ^^ punctuation.section.parens.end.go
-
-    <- chan ident.typ
-//  ^^ keyword.operator.go
-//     ^^^^ storage.type.keyword.chan.go
-//          ^^^^^ variable.other.go
-//               ^ punctuation.accessor.dot.go
-//                ^^^ storage.type.go
-
-    <- chan ident.ident.typ
-//  ^^ keyword.operator.go
-//     ^^^^ storage.type.keyword.chan.go
-//          ^^^^^ variable.other.go
-//               ^ punctuation.accessor.dot.go
-//                ^^^^^ variable.other.go
-//                     ^ punctuation.accessor.dot.go
-//                      ^^^ storage.type.go
-
-    chan <- ident.typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^ keyword.operator.go
-//          ^^^^^ variable.other.go
-//               ^ punctuation.accessor.dot.go
-//                ^^^ storage.type.go
-
-    chan <- ident.ident.typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^ keyword.operator.go
-//          ^^^^^ variable.other.go
-//               ^ punctuation.accessor.dot.go
-//                ^^^^^ variable.other.go
-//                     ^ punctuation.accessor.dot.go
-//                      ^^^ storage.type.go
-
-    chan
-//  ^^^^ storage.type.keyword.chan.go
-    typ
-//  ^^^ storage.type.go
-
-    chan
-//  ^^^^ storage.type.keyword.chan.go
-    ident /**/ . /**/
-//  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    typ
-//  ^^^ storage.type.go
-
-    <-
-//  ^^ keyword.operator.go
-    chan
-//  ^^^^ storage.type.keyword.chan.go
-    ident /**/ . /**/
-//  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    ident /**/ . /**/
-//  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    typ
-//  ^^^ storage.type.go
-
-    chan
-//  ^^^^ storage.type.keyword.chan.go
-    <-    /**/
-//  ^^ keyword.operator.go
-//        ^^^^ comment.block.go
-    ident /**/ . /**/
-//  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    ident /**/ . /**/
-//  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    typ
-//  ^^^ storage.type.go
-
-    chan chan chan typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^ storage.type.keyword.chan.go
-//            ^^^^ storage.type.keyword.chan.go
-//                 ^^^ storage.type.go
-
-    chan *chan **chan ***typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^ keyword.operator.go
-//        ^^^^ storage.type.keyword.chan.go
-//             ^^ keyword.operator.go
-//               ^^^^ storage.type.keyword.chan.go
-//                    ^^^ keyword.operator.go
-//                       ^^^ storage.type.go
-
-    chan struct{}
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^^^ storage.type.keyword.struct.go
-
-    chan struct{} ident
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^^^ storage.type.keyword.struct.go
-//                ^^^^^ variable.other.go
-
-    chan interface{}
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^^^^^^ storage.type.keyword.interface.go
-
-    chan interface{} ident
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^^^^^^ storage.type.keyword.interface.go
-//                   ^^^^^ variable.other.go
-
-    chan func() func() typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^ storage.type.keyword.function.go
-//              ^^^^ storage.type.keyword.function.go
-//                     ^^^ storage.type.go
-
-    chan func() func() typ ident
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^^ storage.type.keyword.function.go
-//              ^^^^ storage.type.keyword.function.go
-//                     ^^^ storage.type.go
-//                         ^^^^^ variable.other.go
-
-    chan
-//  ^^^^ storage.type.keyword.chan.go
-    func() typ
-//  ^^^^ storage.type.keyword.function.go
-//         ^^^ storage.type.go
-
-    chan []typ
-//  ^^^^ storage.type.keyword.chan.go
-//         ^^^ storage.type.go
-
-    chan [][][]typ
-//  ^^^^ storage.type.keyword.chan.go
-//             ^^^ storage.type.go
-
-    chan map[typ]typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^ storage.type.keyword.map.go
-//           ^^^ storage.type.go
-//               ^^^ storage.type.go
-
-
-// ## func
-
-// Note: a function type and the beginning of a non-method function declaration
-// are parsed EXACTLY the same. Function types may contain parameter names.
-// These tests wouldn't be valid Go code by themselves, but they are valid
-// function types.
-
-    func()
-//  ^^^^ storage.type.keyword.function.go
-//      ^ punctuation.section.parens.begin.go
-//       ^ punctuation.section.parens.end.go
-
-    func(typ, typ)
-//  ^^^^ storage.type.keyword.function.go
-//      ^ punctuation.section.parens.begin.go
-//       ^^^ storage.type.go
-//          ^ punctuation.separator.go
-//            ^^^ storage.type.go
-//               ^ punctuation.section.parens.end.go
-
-    func(((typ)), ((typ)))
-//         ^^^ storage.type.go
-//                  ^^^ storage.type.go
-
-    func(...typ)
-//       ^^^ keyword.operator.variadic.go
-//          ^^^ storage.type.go
-
-    func()
-//  ^^^^ storage.type.keyword.function.go
-    ident
-//  ^^^^^ variable.other.go -storage
-
-    func(true false) (nil iota)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^ variable.parameter.go
-//            ^^^^^ storage.type.go
-//                    ^^^ variable.parameter.go
-//                        ^^^^ storage.type.go
-
-    func(param...typ)
-//       ^^^^^ variable.parameter.go
-//            ^^^ keyword.operator.variadic.go
-//               ^^^ storage.type.go
-
-    func(param /**/ ... /**/ typ)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^^ variable.parameter.go
-//             ^^^^ comment.block.go
-//                  ^^^ keyword.operator.variadic.go
-//                      ^^^^ comment.block.go
-//                           ^^^ storage.type.go
-
-    func(param ((typ)), param ...typ)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^^ variable.parameter.go
-//               ^^^ storage.type.go
-//                      ^^^^^ variable.parameter.go
-//                            ^^^ keyword.operator.variadic.go
-//                               ^^^ storage.type.go
-
-    func(param, param ((typ)), param, param ...typ)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^^ variable.parameter.go
-//              ^^^^^ variable.parameter.go
-//                      ^^^ storage.type.go
-//                             ^^^^^ variable.parameter.go
-//                                    ^^^^^ variable.parameter.go
-//                                          ^^^ keyword.operator.variadic.go
-//                                             ^^^ storage.type.go
-
-    func(
-        /**/
-//      ^^^^ comment.block.go
-        typ,
-//      ^^^ storage.type.go
-        ...typ,
-//      ^^^ keyword.operator.variadic.go
-//         ^^^ storage.type.go
-        ((typ)),
-//        ^^^ storage.type.go
-    )
-
-    func(
-        /**/
-//      ^^^^ comment.block.go
-        param, param ((typ)),
-//      ^^^^^ variable.parameter.go
-//             ^^^^^ variable.parameter.go
-//                     ^^^ storage.type.go
-        /**/
-//      ^^^^ comment.block.go
-        param, param typ,
-//      ^^^^^ variable.parameter.go
-//             ^^^^^ variable.parameter.go
-//                   ^^^ storage.type.go
-    )
-
-// Named, multiline, grouped parameters. We can't scope them perfectly. When
-// scoping the first identifier, we don't know whether it's a name or a type.
-// In this scenario, we default to unnamed parameters, because named groups
-// and their type are nearly always written on the same line.
-    func(
-        param,
-//      ^^^^^ storage.type.go
-        param typ,
-//      ^^^^^ storage.type.go
-//            ^^^ storage.type.go
-    )
-
-    func(
-        param, param []typ,
-//      ^^^^^ variable.parameter.go
-//             ^^^^^ variable.parameter.go
-//                     ^^^ storage.type.go
-        param ...typ,
-//      ^^^^^ variable.parameter.go
-//            ^^^ keyword.operator.variadic.go
-//               ^^^ storage.type.go
-    )
-
-    func(
-        param, param (([]typ)),
-//      ^^^^^ variable.parameter.go
-//             ^^^^^ variable.parameter.go
-//                       ^^^ storage.type.go
-        param typ,
-//      ^^^^^ variable.parameter.go
-//            ^^^ storage.type.go
-    )
-
-    func(ident.Type)
-//       ^^^^^ variable.other.go
-//            ^ punctuation.accessor.dot.go
-//             ^^^^ storage.type.go
-
-    func(*ident.Type)
-//       ^ keyword.operator.go
-//        ^^^^^ variable.other.go
-//             ^ punctuation.accessor.dot.go
-//              ^^^^ storage.type.go
-
-    func(...ident.Type)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^ keyword.operator.variadic.go
-//          ^^^^^ variable.other.go
-//               ^ punctuation.accessor.dot.go
-//                ^^^^ storage.type.go
-
-    func(...*ident.Type)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^ keyword.operator.variadic.go
-//          ^ keyword.operator.go
-//           ^^^^^ variable.other.go
-//                ^ punctuation.accessor.dot.go
-//                 ^^^^ storage.type.go
-
-    func(
-        param*ident.Type,
-//      ^^^^^ variable.parameter.go
-//           ^ keyword.operator.go
-//            ^^^^^ variable.other.go
-//                 ^ punctuation.accessor.dot.go
-//                  ^^^^ storage.type.go
-    )
-
-    func(param...typ)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^^ variable.parameter.go
-//            ^^^ keyword.operator.variadic.go
-//               ^^^ storage.type.go
-
-    func(param...ident.Type)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^^ variable.parameter.go
-//            ^^^ keyword.operator.variadic.go
-//               ^^^^^ variable.other.go
-//                    ^ punctuation.accessor.dot.go
-//                     ^^^^ storage.type.go
-
-    func(param...*ident.Type)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^^ variable.parameter.go
-//            ^^^ keyword.operator.variadic.go
-//               ^ keyword.operator.go
-//                ^^^^^ variable.other.go
-//                     ^ punctuation.accessor.dot.go
-//                      ^^^^ storage.type.go
-
-    func(ident .
-//       ^^^^^ variable.other.go
-//             ^ punctuation.accessor.dot.go
-    typ)
-//  ^^^ storage.type.go
-
-    func() typ
-//         ^^^ storage.type.go
-
-    func() ((typ))
-//           ^^^ storage.type.go
-
-    func() (param typ)
-//          ^^^^^ variable.parameter.go
-//                ^^^ storage.type.go
-
-    func() (param ((typ)))
-//          ^^^^^ variable.parameter.go
-//                  ^^^ storage.type.go
-
-    func(typ) (
-//       ^^^ storage.type.go
-        typ
-//      ^^^ storage.type.go
-    )
-
-    func(typ) (
-//       ^^^ storage.type.go
-        param ((typ)),
-//      ^^^^^ variable.parameter.go
-//              ^^^ storage.type.go
-        param typ,
-//      ^^^^^ variable.parameter.go
-//            ^^^ storage.type.go
-    )
-
-// Deranged case
-    func /**/ (
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^ comment.block.go
-//            ^ punctuation.section.parens.begin.go
-        /**/
-//      ^^^^ comment.block.go
-        param, /**/ param /**/ (([]typ)),
-//      ^^^^^ variable.parameter.go
-//           ^ punctuation.separator.go
-//             ^^^^ comment.block.go
-//                  ^^^^^ variable.parameter.go
-//                        ^^^^ comment.block.go
-//                             ^^ punctuation.section.parens.begin.go
-//                               ^ punctuation.section.brackets.begin.go
-//                                ^ punctuation.section.brackets.end.go
-//                                 ^^^ storage.type.go
-//                                    ^^ punctuation.section.parens.end.go
-//                                      ^ punctuation.separator.go
-        /**/
-//      ^^^^ comment.block.go
-        param /**/ * /**/ ident /**/ . /**/ Type,
-//      ^^^^^ variable.parameter.go
-//            ^^^^ comment.block.go
-//                 ^ keyword.operator.go
-//                   ^^^^ comment.block.go
-//                        ^^^^^ variable.other.go
-//                              ^^^^ comment.block.go
-//                                   ^ punctuation.accessor.dot.go
-//                                     ^^^^ comment.block.go
-//                                          ^^^^ storage.type.go
-//                                              ^ punctuation.separator.go
-    ) /**/ (
-//  ^ punctuation.section.parens.end.go
-//    ^^^^ comment.block.go
-//         ^ punctuation.section.parens.begin.go
-        /**/
-//      ^^^^ comment.block.go
-        param, /**/ param /**/ (( /**/ []typ /**/ )),
-//      ^^^^^ variable.parameter.go
-//           ^ punctuation.separator.go
-//             ^^^^ comment.block.go
-//                  ^^^^^ variable.parameter.go
-//                        ^^^^ comment.block.go
-//                             ^^ punctuation.section.parens.begin.go
-//                                ^^^^ comment.block.go
-//                                     ^ punctuation.section.brackets.begin.go
-//                                      ^ punctuation.section.brackets.end.go
-//                                       ^^^ storage.type.go
-//                                           ^^^^ comment.block.go
-//                                                ^^ punctuation.section.parens.end.go
-//                                                  ^ punctuation.separator.go
-        /**/
-//      ^^^^ comment.block.go
-        param /**/ * /**/ ident /**/ . /**/ Type,
-//      ^^^^^ variable.parameter.go
-//            ^^^^ comment.block.go
-//                 ^ keyword.operator.go
-//                   ^^^^ comment.block.go
-//                        ^^^^^ variable.other.go
-//                              ^^^^ comment.block.go
-//                                   ^ punctuation.accessor.dot.go
-//                                     ^^^^ comment.block.go
-//                                          ^^^^ storage.type.go
-//                                              ^ punctuation.separator.go
-    )
-//  ^ punctuation.section.parens.end.go
-
-    func() (
-        param typ)
-//      ^^^^^ variable.parameter.go
-//            ^^^ storage.type.go
-
-    func() func() func() typ
-//  ^^^^ storage.type.keyword.function.go
-//         ^^^^ storage.type.keyword.function.go
-//                ^^^^ storage.type.keyword.function.go
-//                       ^^^ storage.type.go
-
-    func() func() func() ((typ))
-//                         ^^^ storage.type.go
-
-// Deranged case
-    func(param func(param func(param ...typ) func() typ) ...func(param typ))
-//  ^^^^ storage.type.keyword.function.go
-//      ^ punctuation.section.parens.begin.go
-//       ^^^^^ variable.parameter.go
-//             ^^^^ storage.type.keyword.function.go
-//                 ^ punctuation.section.parens.begin.go
-//                  ^^^^^ variable.parameter.go
-//                        ^^^^ storage.type.keyword.function.go
-//                            ^ punctuation.section.parens.begin.go
-//                             ^^^^^ variable.parameter.go
-//                                   ^^^ keyword.operator.variadic.go
-//                                      ^^^ storage.type.go
-//                                         ^ punctuation.section.parens.end.go
-//                                           ^^^^ storage.type.keyword.function.go
-//                                               ^ punctuation.section.parens.begin.go
-//                                                ^ punctuation.section.parens.end.go
-//                                                  ^^^ storage.type.go
-//                                                     ^ punctuation.section.parens.end.go
-//                                                       ^^^ keyword.operator.variadic.go
-//                                                          ^^^^ storage.type.keyword.function.go
-//                                                              ^ punctuation.section.parens.begin.go
-//                                                               ^^^^^ variable.parameter.go
-//                                                                     ^^^ storage.type.go
-//                                                                        ^^ punctuation.section.parens.end.go
-
-
-// ## interface
-
-    interface{}
-//  ^^^^^^^^^ storage.type.keyword.interface.go
-//           ^ meta.type.go punctuation.section.braces.begin.go
-//            ^ meta.type.go punctuation.section.braces.end.go
-
-    interface /**/ {
-//  ^^^^^^^^^ storage.type.keyword.interface.go
-//            ^^^^ comment.block.go
-//                 ^ meta.type.go punctuation.section.braces.begin.go
-
-        Method()
-//      ^^^^^^ meta.type.go entity.name.function.go
-
-        Method /**/ ()
-//      ^^^^^^ meta.type.go entity.name.function.go
-//             ^^^^ meta.type.go comment.block.go
-
-        Method(param typ) (param typ)
-//      ^^^^^^ meta.type.go entity.name.function.go
-//            ^ meta.type.go punctuation.section.parens.begin.go
-//             ^^^^^ meta.type.go variable.parameter.go
-//                   ^^^ meta.type.go storage.type.go
-//                      ^ meta.type.go punctuation.section.parens.end.go
-//                        ^ meta.type.go punctuation.section.parens.begin.go
-//                         ^^^^^ meta.type.go variable.parameter.go
-//                               ^^^ meta.type.go storage.type.go
-//                                  ^ meta.type.go punctuation.section.parens.end.go
-
-        Inherit
-//      ^^^^^^^ meta.type.go entity.other.inherited-class.go
-
-        *ident.Inherit
-//      ^ meta.type.go keyword.operator.go
-//       ^^^^^ meta.type.go variable.other.go
-//            ^ meta.type.go punctuation.accessor.dot.go
-//             ^^^^^^^ meta.type.go entity.other.inherited-class.go
-
-        Inherit // comment
-//      ^^^^^^^ meta.type.go entity.other.inherited-class.go
-//              ^^^^^^^^^^^ meta.type.go comment.line.go
-
-        Inherit /* comment */
-//      ^^^^^^^ meta.type.go entity.other.inherited-class.go
-//              ^^^^^^^^^^^^^ meta.type.go comment.block.go
-
-        Method(
-//      ^^^^^^ meta.type.go entity.name.function.go
-            typ,
-//          ^^^ meta.type.go storage.type.go
-            typ,
-//          ^^^ meta.type.go storage.type.go
-        )
-
-        ident.ident.Inherit
-//      ^^^^^ meta.type.go variable.other.go
-//           ^ meta.type.go punctuation.accessor.dot.go
-//            ^^^^^ meta.type.go variable.other.go
-//                 ^ meta.type.go punctuation.accessor.dot.go
-//                  ^^^^^^^ meta.type.go entity.other.inherited-class.go
-
-        ident /**/ .
-//      ^^^^^ meta.type.go variable.other.go
-//            ^^^^ meta.type.go comment.block.go
-//                 ^ meta.type.go punctuation.accessor.dot.go
-        ident /**/ .
-//      ^^^^^ meta.type.go variable.other.go
-//            ^^^^ meta.type.go comment.block.go
-//                 ^ meta.type.go punctuation.accessor.dot.go
-        Inherit
-//      ^^^^^^^ meta.type.go entity.other.inherited-class.go
-    }
-//  ^ meta.type.go punctuation.section.braces.end.go
-
-    interface
-//  ^^^^^^^^^ storage.type.keyword.interface.go
-    {Method(param typ) typ; Inherit; Method(param typ) typ;}
-//  ^ meta.type.go punctuation.section.braces.begin.go
-//   ^^^^^^ meta.type.go entity.name.function.go
-//         ^ meta.type.go punctuation.section.parens.begin.go
-//          ^^^^^ meta.type.go variable.parameter.go
-//                ^^^ meta.type.go storage.type.go
-//                   ^ meta.type.go punctuation.section.parens.end.go
-//                     ^^^ meta.type.go storage.type.go
-//                        ^ meta.type.go punctuation.terminator.go
-//                          ^^^^^^^ meta.type.go entity.other.inherited-class.go
-//                                 ^ meta.type.go punctuation.terminator.go
-//                                   ^^^^^^ meta.type.go entity.name.function.go
-//                                         ^ meta.type.go punctuation.section.parens.begin.go
-//                                          ^^^^^ meta.type.go variable.parameter.go
-//                                                ^^^ meta.type.go storage.type.go
-//                                                   ^ meta.type.go punctuation.section.parens.end.go
-//                                                     ^^^ meta.type.go storage.type.go
-//                                                        ^ meta.type.go punctuation.terminator.go
-//                                                         ^ meta.type.go punctuation.section.braces.end.go
-
-
-// ## map
-
-    map[typ]typ
-//  ^^^ storage.type.keyword.map.go
-//     ^ punctuation.section.brackets.begin.go
-//      ^^^ storage.type.go
-//         ^ punctuation.section.brackets.end.go
-//          ^^^ storage.type.go
-
-    map[typ]typ ident
-//  ^^^ storage.type.keyword.map.go
-//     ^ punctuation.section.brackets.begin.go
-//      ^^^ storage.type.go
-//         ^ punctuation.section.brackets.end.go
-//          ^^^ storage.type.go
-//              ^^^^^ variable.other.go -storage
-
-    map[typ]
-//  ^^^ storage.type.keyword.map.go
-//      ^^^ storage.type.go
-    ident
-//  ^^^^^ variable.other.go
-
-    map /**/ [/**/ typ /**/] /**/ typ
-//  ^^^ storage.type.keyword.map.go
-//      ^^^^ comment.block.go
-//           ^ punctuation.section.brackets.begin.go
-//            ^^^^ comment.block.go
-//                 ^^^ storage.type.go
-//                     ^^^^ comment.block.go
-//                         ^ punctuation.section.brackets.end.go
-//                           ^^^^ comment.block.go
-//                                ^^^ storage.type.go
-
-    map /**/
-//  ^^^ storage.type.keyword.map.go
-//      ^^^^ comment.block.go
-    /**/ [ /**/
-//  ^^^^ comment.block.go
-//       ^ punctuation.section.brackets.begin.go
-//         ^^^^ comment.block.go
-    /**/ typ /**/ ] /**/ typ
-//  ^^^^ comment.block.go
-//       ^^^ storage.type.go
-//           ^^^^ comment.block.go
-//                ^ punctuation.section.brackets.end.go
-//                  ^^^^ comment.block.go
-//                       ^^^ storage.type.go
-
-    map[typ]map[typ]map[typ]map[typ]typ
-//  ^^^ storage.type.keyword.map.go
-//      ^^^ storage.type.go
-//          ^^^ storage.type.keyword.map.go
-//              ^^^ storage.type.go
-//                  ^^^ storage.type.keyword.map.go
-//                      ^^^ storage.type.go
-//                          ^^^ storage.type.keyword.map.go
-//                              ^^^ storage.type.go
-//                                  ^^^ storage.type.go
-
-    map[chan chan typ]chan chan typ ident
-//  ^^^ storage.type.keyword.map.go
-//      ^^^^ storage.type.keyword.chan.go
-//           ^^^^ storage.type.keyword.chan.go
-//                ^^^ storage.type.go
-//                    ^^^^ storage.type.keyword.chan.go
-//                         ^^^^ storage.type.keyword.chan.go
-//                              ^^^ storage.type.go
-//                                  ^^^^^ variable.other.go
-
-    map[<- chan typ] chan <- typ
-//  ^^^ storage.type.keyword.map.go
-//      ^^ keyword.operator.go
-//         ^^^^ storage.type.keyword.chan.go
-//              ^^^ storage.type.go
-//                   ^^^^ storage.type.keyword.chan.go
-//                        ^^ keyword.operator.go
-//                           ^^^ storage.type.go
-
-    map[func(param typ) typ]func(param typ) typ
-//  ^^^ storage.type.keyword.map.go
-//      ^^^^ storage.type.keyword.function.go
-//           ^^^^^ variable.parameter.go
-//                 ^^^ storage.type.go
-//                      ^^^ storage.type.go
-//                          ^^^^ storage.type.keyword.function.go
-//                               ^^^^^ variable.parameter.go
-//                                     ^^^ storage.type.go
-//                                          ^^^ storage.type.go
-
-    map[map[typ]typ]map[typ]typ
-//  ^^^ storage.type.keyword.map.go
-//      ^^^ storage.type.keyword.map.go
-//          ^^^ storage.type.go
-//              ^^^ storage.type.go
-//                  ^^^ storage.type.keyword.map.go
-//                      ^^^ storage.type.go
-//                          ^^^ storage.type.go
-
-    map[struct{
-//  ^^^ storage.type.keyword.map.go
-//      ^^^^^^ storage.type.keyword.struct.go
-        field typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.go
-    }] struct {
-//     ^^^^^^ storage.type.keyword.struct.go
-//             ^ meta.type.go
-        field typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.go
-//               ^ meta.type.go
-    }
-
-    map[*typ]*typ
-//  ^^^ storage.type.keyword.map.go
-//      ^ keyword.operator.go
-//       ^^^ storage.type.go
-//           ^ keyword.operator.go
-//            ^^^ storage.type.go
-
-    map[ident.Type]ident.Type
-//  ^^^ storage.type.keyword.map.go
-//      ^^^^^ variable.other.go
-//           ^ punctuation.accessor.dot.go
-//            ^^^^ storage.type.go
-//                 ^^^^^ variable.other.go
-//                      ^ punctuation.accessor.dot.go
-//                       ^^^^ storage.type.go
-
-    map[*ident.Type]*ident.Type
-//  ^^^ storage.type.keyword.map.go
-//      ^ keyword.operator.go
-//       ^^^^^ variable.other.go
-//            ^ punctuation.accessor.dot.go
-//             ^^^^ storage.type.go
-//                  ^ keyword.operator.go
-//                   ^^^^^ variable.other.go
-//                        ^ punctuation.accessor.dot.go
-//                         ^^^^ storage.type.go
-
-    map[typ]ident /**/ . /**/
-//  ^^^ storage.type.keyword.map.go
-//      ^^^ storage.type.go
-//          ^^^^^ variable.other.go
-//                ^^^^ comment.block.go
-//                     ^ punctuation.accessor.dot.go
-//                       ^^^^ comment.block.go
-            ident /**/ . /**/
-//          ^^^^^ variable.other.go
-//                ^^^^ comment.block.go
-//                     ^ punctuation.accessor.dot.go
-//                       ^^^^ comment.block.go
-            typ
-//          ^^^ storage.type.go
-
-    map[[0]typ][0]typ
-//  ^^^ storage.type.keyword.map.go
-//       ^ constant.numeric.integer.go
-//         ^^^ storage.type.go
-//              ^ constant.numeric.integer.go
-//                ^^^ storage.type.go
-
-    map[/**/ [0] /**/ typ /**/ ] /**/ [0] /**/ typ
-//  ^^^ storage.type.keyword.map.go
-//      ^^^^ comment.block.go
-//            ^ constant.numeric.integer.go
-//               ^^^^ comment.block.go
-//                    ^^^ storage.type.go
-//                        ^^^^ comment.block.go
-//                               ^^^^ comment.block.go
-//                                     ^ constant.numeric.integer.go
-//                                        ^^^^ comment.block.go
-//                                             ^^^ storage.type.go
-
-
-// ## struct
-
-    struct{}
-//  ^^^^^^ storage.type.keyword.struct.go
-//        ^ meta.type.go punctuation.section.braces.begin.go
-//         ^ meta.type.go punctuation.section.braces.end.go
-
-    struct {field typ}
-//  ^^^^^^ storage.type.keyword.struct.go
-//          ^^^^^ meta.type.go variable.other.member.declaration.go
-//                ^^^ meta.type.go storage.type.go
-
-    struct {field typ;}
-//  ^^^^^^ storage.type.keyword.struct.go
-//          ^^^^^ meta.type.go variable.other.member.declaration.go
-//                ^^^ meta.type.go storage.type.go
-
-    struct {true nil}
-//  ^^^^^^ storage.type.keyword.struct.go
-//          ^^^^ meta.type.go variable.other.member.declaration.go
-//               ^^^ meta.type.go storage.type.go
-
-    struct {embed}
-//  ^^^^^^ storage.type.keyword.struct.go
-//          ^^^^^ meta.type.go entity.other.inherited-class.go
-
-    struct {embed;}
-//  ^^^^^^ storage.type.keyword.struct.go
-//          ^^^^^ meta.type.go entity.other.inherited-class.go
-
-    struct {embed; field typ; *embed; field typ;}
-//  ^^^^^^ storage.type.keyword.struct.go
-//         ^ meta.type.go punctuation.section.braces.begin.go
-//          ^^^^^ meta.type.go entity.other.inherited-class.go
-//               ^ meta.type.go punctuation.terminator.go
-//                 ^^^^^ meta.type.go variable.other.member.declaration.go
-//                       ^^^ meta.type.go storage.type.go
-//                          ^ meta.type.go punctuation.terminator.go
-//                            ^ meta.type.go keyword.operator.go
-//                             ^^^^^ meta.type.go entity.other.inherited-class.go
-//                                  ^ meta.type.go punctuation.terminator.go
-//                                    ^^^^^ meta.type.go variable.other.member.declaration.go
-//                                          ^^^ meta.type.go storage.type.go
-//                                             ^ meta.type.go punctuation.terminator.go
-//                                              ^ meta.type.go punctuation.section.braces.end.go
-
-    struct {
-//  ^^^^^^ storage.type.keyword.struct.go
-        field typ `json:"field"`
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.go
-//                ^^^^^^^^^^^^^^ meta.type.go string.quoted.other.go
-        field /**/ typ /**/ `json:"field"`
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^ meta.type.go comment.block.go
-//                 ^^^ meta.type.go storage.type.go
-//                     ^^^^ meta.type.go comment.block.go
-//                          ^^^^^^^^^^^^^^ meta.type.go string.quoted.other.go
-        typ       `json:"-"`
-//      ^^^ meta.type.go entity.other.inherited-class.go
-//                ^^^^^^^^^^ meta.type.go string.quoted.other.go
-        typ /**/  `json:"-"`
-//      ^^^ meta.type.go entity.other.inherited-class.go
-//          ^^^^ meta.type.go comment.block.go
-//                ^^^^^^^^^^ meta.type.go string.quoted.other.go
-        typ
-//      ^^^ meta.type.go entity.other.inherited-class.go
-
-        typ // comment
-//      ^^^ meta.type.go entity.other.inherited-class.go
-//          ^^^^^^^^^^^ meta.type.go comment.line.go
-
-        typ /* comment */
-//      ^^^ meta.type.go entity.other.inherited-class.go
-//          ^^^^^^^^^^^^^ meta.type.go comment.block.go
-    }
-
-    struct
-//  ^^^^^^ storage.type.keyword.struct.go
-    /**/
-//  ^^^^ comment.block.go
-    {
-//  ^ meta.type.go punctuation.section.braces.begin.go
-        embed
-//      ^^^^^ meta.type.go entity.other.inherited-class.go
-        field typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.go
-        *embed
-//      ^ meta.type.go keyword.operator.go
-//       ^^^^^ meta.type.go entity.other.inherited-class.go
-        field typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.go
-        ident.embed
-//      ^^^^^ meta.type.go variable.other.go
-//           ^ meta.type.go punctuation.accessor.dot.go
-//            ^^^^^ meta.type.go entity.other.inherited-class.go
-        field typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.go
-        *ident.embed
-//      ^ meta.type.go keyword.operator.go
-//       ^^^^^ meta.type.go variable.other.go
-//            ^ meta.type.go punctuation.accessor.dot.go
-//             ^^^^^ meta.type.go entity.other.inherited-class.go
-        field typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.go
-    }
-//  ^ meta.type.go punctuation.section.braces.end.go
-
-    struct {
-        ** /**/ ident /**/ . /**/ ident /**/ . /**/ embed
-//      ^^ meta.type.go keyword.operator.go
-//         ^^^^ meta.type.go comment.block.go
-//              ^^^^^ meta.type.go variable.other.go
-//                    ^^^^ meta.type.go comment.block.go
-//                         ^ meta.type.go punctuation.accessor.dot.go
-//                           ^^^^ meta.type.go comment.block.go
-//                                ^^^^^ meta.type.go variable.other.go
-//                                      ^^^^ meta.type.go comment.block.go
-//                                           ^ meta.type.go punctuation.accessor.dot.go
-//                                             ^^^^ meta.type.go comment.block.go
-//                                                  ^^^^^ meta.type.go entity.other.inherited-class.go
-
-        ** ident /**/ . /**/
-//      ^^ meta.type.go keyword.operator.go
-//         ^^^^^ meta.type.go variable.other.go
-//               ^^^^ meta.type.go comment.block.go
-//                    ^ meta.type.go punctuation.accessor.dot.go
-//                      ^^^^ meta.type.go comment.block.go
-           ident /**/ . /**/
-//         ^^^^^ meta.type.go variable.other.go
-//               ^^^^ meta.type.go comment.block.go
-//                    ^ meta.type.go punctuation.accessor.dot.go
-//                      ^^^^ meta.type.go comment.block.go
-           embed
-//         ^^^^^ meta.type.go entity.other.inherited-class.go
-    }
-
-    struct {
-//  ^^^^^^ storage.type.keyword.struct.go
-        /**/ field /**/ typ /**/
-//      ^^^^ meta.type.go comment.block.go
-//           ^^^^^ meta.type.go variable.other.member.declaration.go
-//                 ^^^^ meta.type.go comment.block.go
-//                      ^^^ meta.type.go storage.type.go
-//                          ^^^^ meta.type.go comment.block.go
-        /**/ field /**/ typ /**/
-//      ^^^^ meta.type.go comment.block.go
-//           ^^^^^ meta.type.go variable.other.member.declaration.go
-//                 ^^^^ meta.type.go comment.block.go
-//                      ^^^ meta.type.go storage.type.go
-//                          ^^^^ meta.type.go comment.block.go
-    }
-
-    struct {
-//  ^^^^^^ storage.type.keyword.struct.go
-        field, field typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//           ^ meta.type.go punctuation.separator.go
-//             ^^^^^ meta.type.go variable.other.member.declaration.go
-//                   ^^^ meta.type.go storage.type.go
-        embed
-//      ^^^^^ meta.type.go entity.other.inherited-class.go
-        field,
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//           ^ meta.type.go punctuation.separator.go
-        field typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.go
-    }
-
-    struct {
-//  ^^^^^^ storage.type.keyword.struct.go
-        field chan typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^ meta.type.go storage.type.keyword.chan.go
-//                 ^^^ meta.type.go storage.type.go
-
-        embed
-//      ^^^^^ meta.type.go entity.other.inherited-class.go
-
-        field <- chan typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^ meta.type.go keyword.operator.go
-//               ^^^^ meta.type.go storage.type.keyword.chan.go
-//                    ^^^ meta.type.go storage.type.go
-
-        embed
-//      ^^^^^ meta.type.go entity.other.inherited-class.go
-
-        field chan <- typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^ meta.type.go storage.type.keyword.chan.go
-//                 ^^ meta.type.go keyword.operator.go
-//                    ^^^ meta.type.go storage.type.go
-
-        embed
-//      ^^^^^ meta.type.go entity.other.inherited-class.go
-
-        field func(param typ) typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^ meta.type.go storage.type.keyword.function.go
-//                ^ meta.type.go punctuation.section.parens.begin.go
-//                 ^^^^^ meta.type.go variable.parameter.go
-//                       ^^^ meta.type.go storage.type.go
-//                          ^ meta.type.go punctuation.section.parens.end.go
-//                            ^^^ meta.type.go storage.type.go
-
-        embed
-//      ^^^^^ meta.type.go entity.other.inherited-class.go
-
-
-        field func(
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^ meta.type.go storage.type.keyword.function.go
-            param typ
-//          ^^^^^ meta.type.go variable.parameter.go
-//                ^^^ meta.type.go storage.type.go
-        ) (
-            param typ
-//          ^^^^^ meta.type.go variable.parameter.go
-//                ^^^ meta.type.go storage.type.go
-        )
-
-        embed
-//      ^^^^^ meta.type.go entity.other.inherited-class.go
-
-        field map[
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.keyword.map.go
-            typ
-//          ^^^ meta.type.go storage.type.go
-        ] typ
-//      ^ meta.type.go punctuation.section.brackets.end.go
-
-        embed
-//      ^^^^^ meta.type.go entity.other.inherited-class.go
-
-        field interface{
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^^^^^^ meta.type.go storage.type.keyword.interface.go
-            method()
-//          ^^^^^^ meta.type.go meta.type.go entity.name.function.go
-        }
-
-        embed
-//      ^^^^^ meta.type.go entity.other.inherited-class.go
-
-        field struct{
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^^^^ meta.type.go storage.type.keyword.struct.go
-            field typ
-//          ^^^^^ meta.type.go meta.type.go variable.other.member.declaration.go
-//                ^^^ meta.type.go meta.type.go storage.type.go
-        }
-
-        field [0]typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^ meta.type.go punctuation.section.brackets.begin.go
-//             ^ meta.type.go constant.numeric.integer.go
-//              ^ meta.type.go punctuation.section.brackets.end.go
-//               ^^^ meta.type.go storage.type.go
-    }
-
-
-// ## Array / Slice
-
-    [0]typ
-//  ^ punctuation.section.brackets.begin.go
-//   ^ constant.numeric.integer.go
-//    ^ punctuation.section.brackets.end.go
-//     ^^^ storage.type.go
-
-    [0x10]typ
-//  ^ punctuation.section.brackets.begin.go
-//   ^^^^ constant.numeric.hex.go
-//       ^ punctuation.section.brackets.end.go
-//        ^^^ storage.type.go
-
-    [0]typ ident
-//  ^ punctuation.section.brackets.begin.go
-//   ^ constant.numeric.integer.go
-//    ^ punctuation.section.brackets.end.go
-//     ^^^ storage.type.go
-//         ^^^^^ variable.other.go
-
-    [...]typ
-//   ^^^ keyword.operator.variadic.go
-//       ^^^ storage.type.go
-
-    [...]typ ident
-//  ^ punctuation.section.brackets.begin.go
-//   ^^^ keyword.operator.variadic.go
-//      ^ punctuation.section.brackets.end.go
-//       ^^^ storage.type.go
-//           ^^^^^ variable.other.go
-
-    []typ
-//  ^ punctuation.section.brackets.begin.go
-//   ^ punctuation.section.brackets.end.go
-//    ^^^ storage.type.go
-
-    [][][]typ ident
-//  ^ punctuation.section.brackets.begin.go
-//   ^ punctuation.section.brackets.end.go
-//    ^ punctuation.section.brackets.begin.go
-//     ^ punctuation.section.brackets.end.go
-//      ^ punctuation.section.brackets.begin.go
-//       ^ punctuation.section.brackets.end.go
-//        ^^^ storage.type.go
-//            ^^^^^ variable.other.go
-
-    [/**/
-//   ^^^^ comment.block.go
-     /**/ 0 /**/ ] /**/ typ
-//   ^^^^ comment.block.go
-//        ^ constant.numeric.integer.go
-//          ^^^^ comment.block.go
-//                 ^^^^ comment.block.go
-//                      ^^^ storage.type.go
-
-    [0]
-    ident
-//  ^^^^^ variable.other.go -storage
-
-    [/**/
-//   ^^^^ comment.block.go
-     /**/] /**/ typ
-//   ^^^^ comment.block.go
-//         ^^^^ comment.block.go
-//              ^^^ storage.type.go
-
-    []
-    ident
-//  ^^^^^ variable.other.go -storage
-
-    []func(
-//    ^^^^ storage.type.keyword.function.go
-        param typ
-//      ^^^^^ variable.parameter.go
-//            ^^^ storage.type.go
-    ) typ ident
-//    ^^^ storage.type.go
-//        ^^^^^ variable.other.go
-
-
-// ## type
-
-    type _ typ
-//  ^^^^ storage.type.keyword.type.go
-//       ^ variable.language.blank.go
-//         ^^^ storage.type.go
-
-    type Type typ
-//  ^^^^ storage.type.keyword.type.go
-//       ^^^^ entity.name.type.go
-//            ^^^ storage.type.go
-
-    type
-//  ^^^^ storage.type.keyword.type.go
-    /**/
-//  ^^^^ comment.block.go
-    Type /**/ * /**/ * /**/ ident /**/ . /**/
-//  ^^^^ entity.name.type.go
-//       ^^^^ comment.block.go
-//            ^ keyword.operator.go
-//              ^^^^ comment.block.go
-//                   ^ keyword.operator.go
-//                     ^^^^ comment.block.go
-//                          ^^^^^ variable.other.go
-//                                ^^^^ comment.block.go
-//                                     ^ punctuation.accessor.dot.go
-//                                       ^^^^ comment.block.go
-        /**/ ident /**/ . /**/
-//      ^^^^ comment.block.go
-//           ^^^^^ variable.other.go
-//                 ^^^^ comment.block.go
-//                      ^ punctuation.accessor.dot.go
-//                        ^^^^ comment.block.go
-        /**/ Type
-//      ^^^^ comment.block.go
-//           ^^^^ storage.type.go
-
-    type Type
-//  ^^^^ storage.type.keyword.type.go
-//       ^^^^ entity.name.type.go
-    ident
-//  ^^^^^ variable.other.go
-
-    type Type; ident
-//  ^^^^ storage.type.keyword.type.go
-//       ^^^^ entity.name.type.go
-//           ^ punctuation.terminator.go
-//             ^^^^^ variable.other.go
-
-    type Type chan typ
-//  ^^^^ storage.type.keyword.type.go
-//       ^^^^ entity.name.type.go
-//            ^^^^ storage.type.keyword.chan.go
-//                 ^^^ storage.type.go
-
-    type Type <- chan typ
-//  ^^^^ storage.type.keyword.type.go
-//       ^^^^ entity.name.type.go
-//            ^^ keyword.operator.go
-//               ^^^^ storage.type.keyword.chan.go
-//                    ^^^ storage.type.go
-
-    type Type chan <- typ
-//  ^^^^ storage.type.keyword.type.go
-//       ^^^^ entity.name.type.go
-//            ^^^^ storage.type.keyword.chan.go
-//                 ^^ keyword.operator.go
-//                    ^^^ storage.type.go
-
-    type Type chan typ ident
-//  ^^^^ storage.type.keyword.type.go
-//       ^^^^ entity.name.type.go
-//            ^^^^ storage.type.keyword.chan.go
-//                 ^^^ storage.type.go
-//                     ^^^^^ variable.other.go
-
-    type Type func(
-//            ^^^^ storage.type.keyword.function.go
-        param typ
-//      ^^^^^ variable.parameter.go
-//            ^^^ storage.type.go
-    ) typ ident
-//    ^^^ storage.type.go
-//        ^^^^^ variable.other.go
-
-    type Type map[typ]typ ident
-//  ^^^^ storage.type.keyword.type.go
-//       ^^^^ entity.name.type.go
-//            ^^^ storage.type.keyword.map.go
-//                ^^^ storage.type.go
-//                    ^^^ storage.type.go
-//                        ^^^^^ variable.other.go
-
-    type Type []typ ident
-//  ^^^^ storage.type.keyword.type.go
-//       ^^^^ entity.name.type.go
-//              ^^^ storage.type.go
-//                  ^^^^^ variable.other.go
-
-    type Type interface {
-//            ^^^^^^^^^ storage.type.keyword.interface.go
-        Method()
-//      ^^^^^^ meta.type.go entity.name.function.go
-        Inherit
-//      ^^^^^^^ meta.type.go entity.other.inherited-class.go
-    } ident
-//    ^^^^^ variable.other.go
-
-    type Type struct {
-//            ^^^^^^ storage.type.keyword.struct.go
-        field typ
-//      ^^^^^ meta.type.go variable.other.member.declaration.go
-//            ^^^ meta.type.go storage.type.go
-    } ident
-//    ^^^^^ variable.other.go
-
-    type (
-        Type typ
-//      ^^^^ entity.name.type.go
-//           ^^^ storage.type.go
-
-        Type typ;
-//      ^^^^ entity.name.type.go
-//           ^^^ storage.type.go
-//              ^ punctuation.terminator.go
-
-        Type typ;;; Type typ
-//      ^^^^ entity.name.type.go
-//           ^^^ storage.type.go
-//              ^^^ punctuation.terminator.go
-//                  ^^^^ entity.name.type.go
-//                       ^^^ storage.type.go
-
-        Type func(
-//      ^^^^ entity.name.type.go
-//           ^^^^ storage.type.keyword.function.go
-        )
-
-        Type map
-//      ^^^^ entity.name.type.go
-//           ^^^ storage.type.keyword.map.go
-        [typ]typ
-//       ^^^ storage.type.go
-//           ^^^ storage.type.go
-
-        Type []typ
-//      ^^^^ entity.name.type.go
-//             ^^^ storage.type.go
-
-        Type interface {
-//      ^^^^ entity.name.type.go
-//           ^^^^^^^^^ storage.type.keyword.interface.go
-            Method()
-//          ^^^^^^ meta.type.go entity.name.function.go
-        }
-
-        Type struct {
-//      ^^^^ entity.name.type.go
-//           ^^^^^^ storage.type.keyword.struct.go
-            field typ
-//          ^^^^^ meta.type.go variable.other.member.declaration.go
-//                ^^^ meta.type.go storage.type.go
-        }
-    )
-
-
-// # Constants and Vars
-
-// Note: initialization expressions may span multiple lines, but the syntax
-// currently doesn't support this due to implementation difficulties. This may
-// cause identifiers in those expressions to be incorrectly scoped as constants
-// or variables.
-
-    const _ = 10
-//  ^^^^^ storage.type.keyword.const.go
-//        ^ variable.language.blank.go
-//          ^ keyword.operator.assignment.go
-//            ^^ constant.numeric.integer.go
-
-    /**/ const
-//  ^^^^ comment.block.go
-//       ^^^^^ storage.type.keyword.const.go
-    /**/ ident /**/ typ /**/ = /**/ iota /**/
-//  ^^^^ comment.block.go
-//       ^^^^^ variable.other.constant.declaration.go
-//             ^^^^ comment.block.go
-//                  ^^^ storage.type.go
-//                      ^^^^ comment.block.go
-//                           ^ keyword.operator.assignment.go
-//                             ^^^^ comment.block.go
-//                                  ^^^^ constant.numeric.integer.go
-//                                       ^^^^ comment.block.go
-
-    const ident, ident = 10, 20
-//  ^^^^^ storage.type.keyword.const.go
-//        ^^^^^ variable.other.constant.declaration.go
-//             ^ punctuation.separator.go
-//               ^^^^^ variable.other.constant.declaration.go
-
-    const ident, ident typ
-//  ^^^^^ storage.type.keyword.const.go
-//        ^^^^^ variable.other.constant.declaration.go
-//             ^ punctuation.separator.go
-//               ^^^^^ variable.other.constant.declaration.go
-//                     ^^^ storage.type.go
-
-    const ident,
-//  ^^^^^ storage.type.keyword.const.go
-//        ^^^^^ variable.other.constant.declaration.go
-//             ^ punctuation.separator.go
-          ident = 10, 20
-//        ^^^^^ variable.other.constant.declaration.go
-
-    const ident,
-//  ^^^^^ storage.type.keyword.const.go
-//        ^^^^^ variable.other.constant.declaration.go
-//             ^ punctuation.separator.go
-          ident typ
-//        ^^^^^ variable.other.constant.declaration.go
-//              ^^^ storage.type.go
-
-    /**/ const
-//  ^^^^ comment.block.go
-//       ^^^^^ storage.type.keyword.const.go
-    (
-//  ^ punctuation.section.parens.begin.go
-        /**/ ident /**/ typ /**/ = /**/ iota + iota /**/
-//      ^^^^ comment.block.go
-//           ^^^^^ variable.other.constant.declaration.go
-//                 ^^^^ comment.block.go
-//                      ^^^ storage.type.go
-//                          ^^^^ comment.block.go
-//                               ^ keyword.operator.assignment.go
-//                                 ^^^^ comment.block.go
-//                                      ^^^^ constant.numeric.integer.go
-//                                           ^ keyword.operator.go
-//                                             ^^^^ constant.numeric.integer.go
-//                                                  ^^^^ comment.block.go
-
-        /**/ ident /**/ = /**/ ident + 100 /**/
-//      ^^^^ comment.block.go
-//           ^^^^^ variable.other.constant.declaration.go
-//                 ^^^^ comment.block.go
-//                      ^ keyword.operator.assignment.go
-//                        ^^^^ comment.block.go
-//                             ^^^^^ variable.other.go
-//                                   ^ keyword.operator.go
-//                                     ^^^ constant.numeric.integer.go
-//                                         ^^^^ comment.block.go
-
-        /**/ ident /**/
-//      ^^^^ comment.block.go
-//           ^^^^^ variable.other.constant.declaration.go
-//                 ^^^^ comment.block.go
-
-        /**/ ident /**/
-//      ^^^^ comment.block.go
-//           ^^^^^ variable.other.constant.declaration.go
-//                 ^^^^ comment.block.go
-
-        ident,
-//      ^^^^^ variable.other.constant.declaration.go
-//           ^ punctuation.separator.go
-        ident typ = 10, 20
-//      ^^^^^ variable.other.constant.declaration.go
-//            ^^^ storage.type.go
-//                ^ keyword.operator.assignment.go
-//                  ^^ constant.numeric.integer.go
-//                    ^ punctuation.separator.go
-//                      ^^ constant.numeric.integer.go
-
-        ident,
-//      ^^^^^ variable.other.constant.declaration.go
-//           ^ punctuation.separator.go
-        ident = ident, ident
-//      ^^^^^ variable.other.constant.declaration.go
-//            ^ keyword.operator.assignment.go
-//              ^^^^^ variable.other.go
-//                   ^ punctuation.separator.go
-//                     ^^^^^ variable.other.go
-
-        ident,
-//      ^^^^^ variable.other.constant.declaration.go
-//           ^ punctuation.separator.go
-        ident
-//      ^^^^^ variable.other.constant.declaration.go
-
-// This verifies that we're not still trying to match a type after the preceding
-// identifier.
-
-        ident,
-//      ^^^^^ variable.other.constant.declaration.go
-//           ^ punctuation.separator.go
-        ident
-//      ^^^^^ variable.other.constant.declaration.go
-
-        ident =
-//      ^^^^^ variable.other.constant.declaration.go
-//            ^ keyword.operator.assignment.go
-        "blah"
-//      ^^^^^^ string.quoted.double.go
-
-        ident =
-//      ^^^^^ variable.other.constant.declaration.go
-//            ^ keyword.operator.assignment.go
-        10
-//      ^^ constant.numeric.integer.go
-
-        ident =
-//      ^^^^^ variable.other.constant.declaration.go
-//            ^ keyword.operator.assignment.go
-        iota + iota
-//      ^^^^ constant.numeric.integer.go
-//           ^ keyword.operator.go
-//             ^^^^ constant.numeric.integer.go
-
-        iota = iota
-//      ^^^^ variable.other.constant.declaration.go
-//           ^ keyword.operator.assignment.go
-//             ^^^^ constant.numeric.integer.go
-    )
-
-    const ident typ = ident +
-//  ^^^^^ storage.type.keyword.const.go
-//        ^^^^^ variable.other.constant.declaration.go
-//              ^^^ storage.type.go
-//                  ^ keyword.operator.assignment.go
-//                    ^^^^^ variable.other.go
-//                          ^ keyword.operator.go
-        ident +
-//      ^^^^^ variable.other.go
-//            ^ keyword.operator.go
-        ident +
-//      ^^^^^ variable.other.go
-//            ^ keyword.operator.go
-        ident
-//      ^^^^^ variable.other.go
-
-    const (
-//  ^^^^^ storage.type.keyword.const.go
-        ident typ = ident +
-//      ^^^^^ variable.other.constant.declaration.go
-//            ^^^ storage.type.go
-//                ^ keyword.operator.assignment.go
-//                  ^^^^^ variable.other.go
-//                        ^ keyword.operator.go
-            ident +
-//          ^^^^^ variable.other.constant.declaration.go
-//                ^ keyword.operator.go
-
-// BUG: this is incorrectly scoped as a type. TODO consider detecting multiline
-// expressions, or find another way of handling this properly.
-            ident +
-
-            ident
-//          ^^^^^ variable.other.constant.declaration.go
-    )
-
-// iota is predefined only in constant declarations. It's not a reserved word.
-    func _() {
-        var iota = 0
-//      ^^^ storage.type.keyword.var.go
-//          ^^^^ variable.declaration.go
-//               ^ keyword.operator.assignment.go
-//                 ^ constant.numeric.integer.go
-        var _ = iota
-//      ^^^ storage.type.keyword.var.go
-//          ^ variable.language.blank.go
-//            ^ keyword.operator.assignment.go
-//              ^^^^ variable.other.go -constant
-    }
-
-    var _ = log.Println
-//  ^^^ storage.type.keyword.var.go
-//      ^ variable.language.blank.go
-//        ^ keyword.operator.assignment.go
-//          ^^^ variable.other.go
-//             ^ punctuation.accessor.dot.go
-//              ^^^^^^^ variable.other.member.go
-
-    /**/ var
-//  ^^^^ comment.block.go
-//       ^^^ storage.type.keyword.var.go
-    /**/ ident /**/ typ /**/ = /**/ 10 /**/
-//  ^^^^ comment.block.go
-//       ^^^^^ variable.declaration.go
-//             ^^^^ comment.block.go
-//                  ^^^ storage.type.go
-//                      ^^^^ comment.block.go
-//                           ^ keyword.operator.assignment.go
-//                             ^^^^ comment.block.go
-//                                  ^^ constant.numeric.integer.go
-//                                     ^^^^ comment.block.go
-
-    var ident, ident = 10, 20
-//  ^^^ storage.type.keyword.var.go
-//      ^^^^^ variable.declaration.go
-//           ^ punctuation.separator.go
-//             ^^^^^ variable.declaration.go
-
-    var ident, ident typ
-//  ^^^ storage.type.keyword.var.go
-//      ^^^^^ variable.declaration.go
-//           ^ punctuation.separator.go
-//             ^^^^^ variable.declaration.go
-//                   ^^^ storage.type.go
-
-    var ident,
-//  ^^^ storage.type.keyword.var.go
-//      ^^^^^ variable.declaration.go
-//           ^ punctuation.separator.go
-        ident = 10, 20
-//      ^^^^^ variable.declaration.go
-
-    var ident,
-//  ^^^ storage.type.keyword.var.go
-//      ^^^^^ variable.declaration.go
-//           ^ punctuation.separator.go
-        ident typ
-//      ^^^^^ variable.declaration.go
-//            ^^^ storage.type.go
-
-    /**/ var
-//  ^^^^ comment.block.go
-//       ^^^ storage.type.keyword.var.go
-    (
-//  ^ punctuation.section.parens.begin.go
-        /**/ ident /**/ typ /**/ = /**/ ident /**/ + /**/ 20 /**/
-//      ^^^^ comment.block.go
-//           ^^^^^ variable.declaration.go
-//                 ^^^^ comment.block.go
-//                      ^^^ storage.type.go
-//                          ^^^^ comment.block.go
-//                               ^ keyword.operator.assignment.go
-//                                 ^^^^ comment.block.go
-//                                      ^^^^^ variable.other.go
-//                                            ^^^^ comment.block.go
-//                                                 ^ keyword.operator.go
-//                                                   ^^^^ comment.block.go
-//                                                        ^^ constant.numeric.integer.go
-//                                                           ^^^^ comment.block.go
-
-        /**/ ident /**/ = /**/ ident + 20 /**/
-//      ^^^^ comment.block.go
-//           ^^^^^ variable.declaration.go
-//                 ^^^^ comment.block.go
-//                      ^ keyword.operator.assignment.go
-//                        ^^^^ comment.block.go
-//                             ^^^^^ variable.other.go
-//                                   ^ keyword.operator.go
-//                                     ^^ constant.numeric.integer.go
-//                                        ^^^^ comment.block.go
-
-        ident,
-//      ^^^^^ variable.declaration.go
-//           ^ punctuation.separator.go
-        ident typ = ident, ident
-//      ^^^^^ variable.declaration.go
-//            ^^^ storage.type.go
-//                ^ keyword.operator.assignment.go
-//                  ^^^^^ variable.other.go
-//                       ^ punctuation.separator.go
-//                         ^^^^^ variable.other.go
-    )
-//  ^ punctuation.section.parens.end.go
-
-// ## Short Variable Declaration
-
-    ident := expr
-//  ^^^^^ variable.declaration.go
-//        ^^ keyword.operator.assignment.go
-//           ^^^^ variable.other.go
-
-    ident, ident := expr
-//  ^^^^^ variable.declaration.go
-//       ^ punctuation.separator.go
-//         ^^^^^ variable.declaration.go
-//               ^^ keyword.operator.assignment.go
-//                  ^^^^ variable.other.go
-
-    ident, ident :=
-//  ^^^^^ variable.declaration.go
-//       ^ punctuation.separator.go
-//         ^^^^^ variable.declaration.go
-//               ^^ keyword.operator.assignment.go
-    expr
-//  ^^^^ variable.other.go
-
-    ident = expr
-//  ^^^^^ variable.other.go
-//        ^ keyword.operator.assignment.go
-//          ^^^^ variable.other.go
-
-// # Literals
-
-// ## Integers
-
-// ### Decimal
-
-    0; 123456789; -0; -123456789;
-//  ^ constant.numeric.integer.go
-//     ^^^^^^^^^ constant.numeric.integer.go
-//                ^ keyword.operator.go
-//                 ^ constant.numeric.integer.go
-//                    ^ keyword.operator.go
-//                     ^^^^^^^^^ constant.numeric.integer.go
-
-// ### Octal
-
-    00; 01234567; -01234567;
-//  ^^ constant.numeric.octal.go
-//      ^^^^^^^^ constant.numeric.octal.go
-//                ^ keyword.operator.go
-//                 ^^^^^^^^ constant.numeric.octal.go
-
-    08; 09;
-//  ^^ invalid.illegal.go
-//      ^^ invalid.illegal.go
-
-// ### Hex
-
-    0x0; 0x0123456789ABCDEFabcdef; -0x0123456789ABCDEFabcdef;
-//  ^^^ constant.numeric.hex.go
-//       ^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
-//                                 ^ keyword.operator.go
-//                                  ^^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.hex.go
-
-// ## Floats
-
-    000.000; 123.456; .0; 1.;
-//  ^^^^^^^ constant.numeric.float.go
-//     ^ punctuation.separator.decimal.go
-//           ^^^ constant.numeric.float.go
-//              ^ punctuation.separator.decimal.go
-//               ^^^ constant.numeric.float.go
-//                    ^^ invalid.deprecated.go
-//                        ^^ invalid.deprecated.go
-
-    -000.000; -123.456; -.0; -1.;
-//  ^ keyword.operator.go
-//   ^^^^^^^ constant.numeric.float.go
-//      ^ punctuation.separator.decimal.go
-//            ^ keyword.operator.go
-//             ^^^^^^^ constant.numeric.float.go
-//                ^ punctuation.separator.decimal.go
-//                      ^ keyword.operator.go
-//                       ^^ invalid.deprecated.go
-//                           ^ keyword.operator.go
-//                            ^^ invalid.deprecated.go
-
-    0e+0; 0E+0; 0.0e+0; 0.0E+0; 123.456e+789;
-//  ^^^^ constant.numeric.float.go
-//   ^^ punctuation.separator.exponent.go
-//        ^^^^ constant.numeric.float.go
-//         ^^ punctuation.separator.exponent.go
-//              ^^^^^^ constant.numeric.float.go
-//                      ^^^^^^ constant.numeric.float.go
-//                       ^ punctuation.separator.decimal.go
-//                         ^^ punctuation.separator.exponent.go
-//                           ^ constant.numeric.float.go
-//                            ^ punctuation.terminator.go
-//                              ^^^^^^^^^^^^ constant.numeric.float.go
-//                                 ^ punctuation.separator.decimal.go
-//                                     ^^ punctuation.separator.exponent.go
-
-    0e-0; 0E-0; 0.0e-0; 0.0E-0; 123.456e-789;
-//  ^^^^ constant.numeric.float.go
-//   ^^ punctuation.separator.exponent.go
-//        ^^^^ constant.numeric.float.go
-//         ^^ punctuation.separator.exponent.go
-//           ^ constant.numeric.float.go
-//              ^^^^^^ constant.numeric.float.go
-//               ^ punctuation.separator.decimal.go
-//                 ^^ punctuation.separator.exponent.go
-//                      ^^^^^^ constant.numeric.float.go
-//                       ^ punctuation.separator.decimal.go
-//                         ^^ punctuation.separator.exponent.go
-//                              ^^^^^^^^^^^^ constant.numeric.float.go
-//                                 ^ punctuation.separator.decimal.go
-//                                     ^^ punctuation.separator.exponent.go
-
-    0.e+0; .0e+0; 0.e-0; .0e-0;
-//  ^^^^^ invalid.deprecated.go
-//         ^^^^^ invalid.deprecated.go
-//                ^^^^^ invalid.deprecated.go
-//                       ^^^^^ invalid.deprecated.go
-
-// ## Imaginary
-
-    000i; 100i; -100i;
-//  ^^^^ constant.numeric.imaginary.go
-//     ^ storage.type.numeric.imaginary.go
-//        ^^^^ constant.numeric.imaginary.go
-//           ^ storage.type.numeric.imaginary.go
-//              ^ keyword.operator.go
-//               ^^^^ constant.numeric.imaginary.go
-//                  ^ storage.type.numeric.imaginary.go
-
-    123.456i; -123.456i;
-//  ^^^^^^^^ constant.numeric.imaginary.go
-//     ^ punctuation.separator.decimal.go
-//         ^ storage.type.numeric.imaginary.go
-//            ^ keyword.operator.go
-//             ^^^^^^^^ constant.numeric.imaginary.go
-//                ^ punctuation.separator.decimal.go
-//                    ^ storage.type.numeric.imaginary.go
-
-    1e+2i; 1e-2i; 1.2e+3i; 1.2e-3i; 1E+2i; 1E-2i; 1.2E+3i; 1.2E-3i;
-//  ^^^^^ constant.numeric.imaginary.go
-//   ^^ punctuation.separator.exponent.go
-//      ^ storage.type.numeric.imaginary.go
-//         ^^^^^ constant.numeric.imaginary.go
-//          ^^ punctuation.separator.exponent.go
-//             ^ storage.type.numeric.imaginary.go
-//                ^^^^^^^ constant.numeric.imaginary.go
-//                 ^ punctuation.separator.decimal.go
-//                   ^^ punctuation.separator.exponent.go
-//                      ^ storage.type.numeric.imaginary.go
-//                         ^^^^^^^ constant.numeric.imaginary.go
-//                          ^ punctuation.separator.decimal.go
-//                            ^^ punctuation.separator.exponent.go
-//                               ^ storage.type.numeric.imaginary.go
-//                                  ^^^^^ constant.numeric.imaginary.go
-//                                   ^^ punctuation.separator.exponent.go
-//                                      ^ storage.type.numeric.imaginary.go
-//                                         ^^^^^ constant.numeric.imaginary.go
-//                                          ^^ punctuation.separator.exponent.go
-//                                             ^ storage.type.numeric.imaginary.go
-//                                                ^^^^^^^ constant.numeric.imaginary.go
-//                                                 ^ punctuation.separator.decimal.go
-//                                                   ^^ punctuation.separator.exponent.go
-//                                                      ^ storage.type.numeric.imaginary.go
-//                                                         ^^^^^^^ constant.numeric.imaginary.go
-//                                                          ^ punctuation.separator.decimal.go
-//                                                            ^^ punctuation.separator.exponent.go
-//                                                               ^ storage.type.numeric.imaginary.go
-
-    0.i; .0i; -0.i; -.0i;
-//  ^^^ invalid.deprecated.go
-//       ^^^ invalid.deprecated.go
-//            ^ keyword.operator.go
-//             ^^^ invalid.deprecated.go
-//                  ^ keyword.operator.go
-//                   ^^^ invalid.deprecated.go
-
-    0.e+0i; .0e+0i; 0.e-0i; .0e-0i;
-//  ^^^^^^ invalid.deprecated.go
-//          ^^^^^^ invalid.deprecated.go
-//                  ^^^^^^ invalid.deprecated.go
-//                          ^^^^^^ invalid.deprecated.go
-
-// ## Runes
-
-    ' '
-//  ^^^ constant.character.go
-
-    '0'
-//  ^^^ constant.character.go
-
-// Escapes:
-
-    '\n'
-//  ^^^^ constant.character.go
-//   ^^ constant.character.go constant.character.escape.go
-
-    '\x00'
-//  ^^^^^^ constant.character.go
-//   ^^^^ constant.character.go constant.character.escape.go
-
-    '\u0000'
-//  ^^^^^^^^ constant.character.go
-//   ^^^^^^ constant.character.go constant.character.escape.go
-
-    '\U00000000'
-//  ^^^^^^^^^^^^ constant.character.go
-//   ^^^^^^^^^^ constant.character.go constant.character.escape.go
-
-    '\000'
-//  ^^^^^^ constant.character.go
-//   ^^^^ constant.character.go constant.character.escape.go
-
-// ## Strings
-
-    "one two"
-//  ^ punctuation.definition.string.begin.go
-//  ^^^^^^^^^ string.quoted.double.go
-//          ^ punctuation.definition.string.end.go
-    "one \\ \n two"
-//  ^^^^^^^^^^^^^^^ string.quoted.double.go
-//       ^^ constant.character.escape.go
-    "one %% two"
-//  ^^^^^^^^^^^^ string.quoted.double.go
-//       ^^ constant.character.escape.go
-    "one % two"
-//  ^^^^^^^^^^^ string.quoted.double.go
-//       ^^^ constant.other.placeholder.go
-    "one %v two"
-//  ^^^^^^^^^^^^ string.quoted.double.go
-//       ^^ constant.other.placeholder.go
-    "one %+v two"
-//  ^^^^^^^^^^^^^ string.quoted.double.go
-//       ^^^ constant.other.placeholder.go
-    "one %1.2d two"
-//  ^^^^^^^^^^^^^^^ string.quoted.double.go
-//       ^^^^^ constant.other.placeholder.go
-    "one %[1] two"
-//  ^^^^^^^^^^^ string.quoted.double.go
-//       ^^^^^^ constant.other.placeholder.go
-    "one %[1]v two"
-//  ^^^^^^^^^^^^ string.quoted.double.go
-//       ^^^^^ constant.other.placeholder.go
-    "one %[1]+v two"
-//  ^^^^^^^^^^^^^ string.quoted.double.go
-//       ^^^^^^ constant.other.placeholder.go
-    "one %[1]1.2d two"
-//  ^^^^^^^^^^^^^^^ string.quoted.double.go
-//       ^^^^^^^^ constant.other.placeholder.go
-    "%"
-//  ^^^ string.quoted.double.go
-//   ^ -constant.other.placeholder
-
-    "one /* two */ three"
-//  ^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.go -comment
-
-    "_\n_"
-//  ^^^^^^ string.quoted.double.go
-//    ^^ string.quoted.double.go constant.character.escape.go
-//   ^ -constant.character.escape
-//      ^ -constant.character.escape
-
-    "_\x00_"
-//  ^^^^^^^^ string.quoted.double.go
-//    ^^^^ string.quoted.double.go constant.character.escape.go
-//   ^ -constant.character.escape
-//        ^ -constant.character.escape
-
-    "_\u0000_"
-//  ^^^^^^^^^^ string.quoted.double.go
-//    ^^^^^^ string.quoted.double.go constant.character.escape.go
-//   ^ -constant.character.escape
-//          ^ -constant.character.escape
-
-    "_\U00000000_"
-//  ^^^^^^^^^^^^^^ string.quoted.double.go
-//    ^^^^^^^^^^ string.quoted.double.go constant.character.escape.go
-//   ^ -constant.character.escape
-//              constant.character.escape
-
-    "_\000_"
-//  ^^^^^^^^ string.quoted.double.go
-//    ^^^^ string.quoted.double.go constant.character.escape.go
-//   ^ -constant.character.escape
-//        ^ -constant.character.escape
-
-    `one two`
-//  ^ punctuation.definition.string.begin.go
-//  ^^^^^^^^^ string.quoted.other.go
-//          ^ punctuation.definition.string.end.go
-    `one \\ \n two`
-//  ^^^^^^^^^^^^^^^ string.quoted.other.go -constant.character.escape
-    `one %% two`
-//  ^^^^^^^^^^^^ string.quoted.other.go
-//       ^^ constant.character.escape.go
-    `one % two`
-//  ^^^^^^^^^^^ string.quoted.other.go
-//       ^^^ constant.other.placeholder.go
-    `one %v two`
-//  ^^^^^^^^^^^^ string.quoted.other.go
-//       ^^ constant.other.placeholder.go
-    `one %+v two`
-//  ^^^^^^^^^^^^^ string.quoted.other.go
-//       ^^^ constant.other.placeholder.go
-    `one %1.2d two`
-//  ^^^^^^^^^^^^^^^ string.quoted.other.go
-//       ^^^^^ constant.other.placeholder.go
-    `one %[1] two`
-//  ^^^^^^^^^^^ string.quoted.other.go
-//       ^^^^^^ constant.other.placeholder.go
-    `one %[1]v two`
-//  ^^^^^^^^^^^^ string.quoted.other.go
-//       ^^^^^ constant.other.placeholder.go
-    `one %[1]+v two`
-//  ^^^^^^^^^^^^^ string.quoted.other.go
-//       ^^^^^^ constant.other.placeholder.go
-    `one %[1]1.2d two`
-//  ^^^^^^^^^^^^^^^ string.quoted.other.go
-//       ^^^^^^^^ constant.other.placeholder.go
-    `%`
-//  ^^^ string.quoted.other.go
-//   ^ -constant.other.placeholder
-
-    `
-//  ^ string.quoted.other.go punctuation.definition.string.begin.go
-    one
-//  ^^^ string.quoted.other.go
-    two
-//  ^^^ string.quoted.other.go
-    three
-//  ^^^^^ string.quoted.other.go
-    `
-//  ^ string.quoted.other.go punctuation.definition.string.end.go
-
-    `one /* two */ three`
-//  ^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.go -comment
-
-
-// # Operators
-
-    !=
-//  ^^ keyword.operator.go
-    !
-//  ^ keyword.operator.go
-    %=
-//  ^^ keyword.operator.assignment.go
-    %
-//  ^ keyword.operator.go
-    &&
-//  ^^ keyword.operator.go
-    &=
-//  ^^ keyword.operator.assignment.go
-    &^=
-//  ^ keyword.operator.go
-    &^
-//  ^^ keyword.operator.go
-    &
-//  ^ keyword.operator.go
-    *=
-//  ^^ keyword.operator.assignment.go
-    *
-//  ^ keyword.operator.go
-    ++
-//  ^^ keyword.operator.go
-    +=
-//  ^^ keyword.operator.assignment.go
-    +
-//  ^ keyword.operator.go
-    --
-//  ^^ keyword.operator.assignment.go
-    -=
-//  ^^ keyword.operator.assignment.go
-    -
-//  ^ keyword.operator.go
-    /=
-//  ^^ keyword.operator.assignment.go
-    /
-//  ^ keyword.operator.go
-    :=
-//  ^^ keyword.operator.assignment.go
-    <-
-//  ^^ keyword.operator.go
-    <
-//  ^ keyword.operator.go
-    <<=
-//  ^^ keyword.operator.go
-    <<
-//  ^^ keyword.operator.go
-    <=
-//  ^ keyword.operator.go
-    ==
-//  ^^ keyword.operator.go
-    =
-//  ^ keyword.operator.assignment.go
-    >=
-//  ^^ keyword.operator.assignment.go
-    >>=
-//  ^^^ keyword.operator.assignment.go
-    >>
-//  ^^ keyword.operator.go
-    >
-//  ^ keyword.operator.go
-    ^=
-//  ^^ keyword.operator.assignment.go
-    ^
-//  ^ keyword.operator.go
-    |=
-//  ^^ keyword.operator.assignment.go
-    ||
-//  ^^ keyword.operator.go
-    |
-//  ^ keyword.operator.go
-
-
-// # Punctuation
-
-// Note: [] can denote array and slice types. It's covered in the type section.
-
-    , ... : ; . () [] {}
-//  ^ punctuation.separator.go
-//    ^^^ keyword.operator.variadic.go
-//        ^ punctuation.separator.go
-//          ^ punctuation.terminator.go
-//            ^ punctuation.accessor.dot.go
-//              ^ punctuation.section.parens.begin.go
-//               ^ punctuation.section.parens.end.go
-//                 ^ punctuation.section.brackets.begin.go
-//                  ^ punctuation.section.brackets.end.go
-//                    ^ meta.block.go punctuation.section.braces.begin.go
-//                     ^ meta.block.go punctuation.section.braces.end.go
-
-    {
-//  ^ meta.block.go punctuation.section.braces.begin.go
-        ident
-//      ^^^^^ meta.block.go variable.other.go
-    }
-//  ^ meta.block.go punctuation.section.braces.end.go
-
-// ## Selector
-
-// ### Member
-
-    ident.ident
-//  ^^^^^ variable.other.go
-//       ^ punctuation.accessor.dot.go
-//        ^^^^^ variable.other.member.go
-
-    ident.ident.ident
-//  ^^^^^ variable.other.go
-//       ^ punctuation.accessor.dot.go
-//        ^^^^^ variable.other.member.go
-//             ^ punctuation.accessor.dot.go
-//              ^^^^^ variable.other.member.go
-
-    ident /**/ . /**/
-//  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    ident /**/ . /**/
-//  ^^^^^ variable.other.member.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    ident
-//  ^^^^^ variable.other.member.go
-
-// ### Type Assertion
-
-    ident.(ident)
-//  ^^^^^ variable.other.go
-//       ^ punctuation.accessor.dot.go
-//         ^^^^^ storage.type.go
-
-    ident
-//  ^^^^^ variable.other.go
-    /**/./**/
-//      ^ punctuation.accessor.dot.go
-    (/* ident */ ident /* ident */ ident)
-//   ^^^^^^^^^^^ comment.block.go
-//               ^^^^^ storage.type.go
-//                     ^^^^^^^^^^^ comment.block.go
-//                                 ^^^^^ variable.other.go
-
-    ident.(chan typ)
-//  ^^^^^ variable.other.go
-//       ^ punctuation.accessor.dot.go
-//         ^^^^ storage.type.keyword.chan.go
-//              ^^^ storage.type.go
-
-    ident.(***ident)
-//         ^^^ keyword.operator.go
-//            ^^^^^ storage.type.go
-
-    ident.((***ident))
-//  ^^^^^ variable.other.go
-//       ^ punctuation.accessor.dot.go
-//        ^^ punctuation.section.parens.begin.go
-//          ^^^ keyword.operator.go
-//             ^^^^^ storage.type.go
-//                  ^^ punctuation.section.parens.end.go
-
-    ident.ident.ident.(ident.ident)
-//  ^^^^^ variable.other.go
-//       ^ punctuation.accessor.dot.go
-//        ^^^^^ variable.other.member.go
-//             ^ punctuation.accessor.dot.go
-//              ^^^^^ variable.other.member.go
-//                   ^ punctuation.accessor.dot.go
-//                    ^ punctuation.section.parens.begin.go
-//                     ^^^^^ variable.other.go
-//                          ^ punctuation.accessor.dot.go
-//                           ^^^^^ storage.type.go
-//                                ^ punctuation.section.parens.end.go
-
-    ((ident.ident.ident)).((ident.ident))
-//  ^^ punctuation.section.parens.begin.go
-//    ^^^^^ variable.other.go
-//         ^ punctuation.accessor.dot.go
-//          ^^^^^ variable.other.member.go
-//               ^ punctuation.accessor.dot.go
-//                ^^^^^ variable.other.member.go
-//                     ^^ punctuation.section.parens.end.go
-//                       ^ punctuation.accessor.dot.go
-//                        ^^ punctuation.section.parens.begin.go
-//                          ^^^^^ variable.other.go
-//                               ^ punctuation.accessor.dot.go
-//                                ^^^^^ storage.type.go
-//                                     ^^ punctuation.section.parens.end.go
-
-// Note: at the time of writing, in Go 1, types can be nested only in modules.
-// Doubly-nested types don't exist. This may change in the future. We still make
-// sure that the syntax doesn't do something weird.
-
-    ident.(ident.ident.ident)
-//         ^^^^^ variable.other.go
-//              ^ punctuation.accessor.dot.go
-//                    ^ punctuation.accessor.dot.go
-//                     ^^^^^ storage.type.go
-
-    ident.((ident.ident.ident))
-//          ^^^^^ variable.other.go
-//               ^ punctuation.accessor.dot.go
-//                     ^ punctuation.accessor.dot.go
-//                      ^^^^^ storage.type.go
-
-// ## Parens
-
-// Note: we can't syntactically disambiguate calls and casts.
-
-    ident()
-//  ^^^^ variable.function.go
-
-    ident /**/ (
-//  ^^^^ variable.function.go
-    )
-
-    ident.ident()
-//  ^^^^^ variable.other.go
-//       ^ punctuation.accessor.dot.go
-//        ^^^^^ variable.function.go
-
-    ident
-//  ^^^^^ variable.other.go
-    /**/./**/
-//      ^ punctuation.accessor.dot.go
-    ident()
-//  ^^^^^ variable.function.go
-
-    ident.ident.ident(ident)
-//  ^^^^^ variable.other.go
-//       ^ punctuation.accessor.dot.go
-//        ^^^^^ variable.other.member.go
-//             ^ punctuation.accessor.dot.go
-//              ^^^^^ variable.function.go
-//                   ^ punctuation.section.parens.begin.go
-//                    ^^^^^ variable.other.go
-//                         ^ punctuation.section.parens.end.go
-
-    ident /**/ . /**/
-//  ^^^^^ variable.other.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    ident /**/ . /**/
-//  ^^^^^ variable.other.member.go
-//        ^^^^ comment.block.go
-//             ^ punctuation.accessor.dot.go
-//               ^^^^ comment.block.go
-    ident /**/ ((/**/ ident /**/))
-//  ^^^^^ variable.function.go
-//        ^^^^ comment.block.go
-//             ^^ punctuation.section.parens.begin.go
-//               ^^^^ comment.block.go
-//                    ^^^^^ variable.other.go
-//                          ^^^^ comment.block.go
-//                              ^^ punctuation.section.parens.end.go
-
-    (ident)
-//   ^^^^^ variable.other.go
-
-    (ident)(ident)
-//   ^^^^^ variable.function.go
-//          ^^^^^ variable.other.go
-
-    ((ident))((ident))
-//  ^^ punctuation.section.parens.begin.go
-//    ^^^^^ variable.function.go
-//         ^^ punctuation.section.parens.end.go
-//           ^^ punctuation.section.parens.begin.go
-//             ^^^^^ variable.other.go
-//                  ^^ punctuation.section.parens.end.go
-
-    ((
-//  ^^ punctuation.section.parens.begin.go
-        ident /**/ . /**/
-//      ^^^^^ variable.other.go
-//            ^^^^ comment.block.go
-//                 ^ punctuation.accessor.dot.go
-//                   ^^^^ comment.block.go
-        ident /**/ . /**/
-//      ^^^^^ variable.other.member.go
-//            ^^^^ comment.block.go
-//                 ^ punctuation.accessor.dot.go
-//                   ^^^^ comment.block.go
-        ident /**/ )) /**/ ((
-//      ^^^^^ variable.function.go
-//            ^^^^ comment.block.go
-//                 ^^ punctuation.section.parens.end.go
-//                    ^^^^ comment.block.go
-//                         ^^ punctuation.section.parens.begin.go
-        ident
-//      ^^^^^ variable.other.go
-    ))
-//  ^^ punctuation.section.parens.end.go
-
-    (*chan typ)(ident)
-//   ^ keyword.operator.go
-//    ^^^^ storage.type.keyword.chan.go
-//         ^^^ storage.type.go
-//              ^^^^^ variable.other.go
-
-    map[typ]typ(ident)
-//  ^^^ storage.type.keyword.map.go
-//      ^^^ storage.type.go
-//          ^^^ storage.type.go
-//              ^^^^^ variable.other.go
-
-    (map[typ]typ)(ident)
-//   ^^^ storage.type.keyword.map.go
-//       ^^^ storage.type.go
-//           ^^^ storage.type.go
-//                ^^^^^ variable.other.go
-
-    []typ(ident)
-//    ^^^ storage.type.go
-//        ^^^^^ variable.other.go
-
-    ([]typ)(ident)
-//     ^^^ storage.type.go
-//          ^^^^^ variable.other.go
-
-
-// # Keywords
-
-// Some keywords are covered elsewhere in the test.
-
-    break
-//  ^^^^^ keyword.control.go
-    case
-//  ^^^^ keyword.control.go
-    continue
-//  ^^^^^^^^ keyword.control.go
-    default
-//  ^^^^^^^ keyword.control.go
-    defer
-//  ^^^^^ keyword.control.go
-    else
-//  ^^^^ keyword.control.go
-    fallthrough
-//  ^^^^^^^^^^^ keyword.control.go
-    for
-//  ^^^ keyword.control.go
-    go
-//  ^^ keyword.control.go
-    goto
-//  ^^^^ keyword.control.go
-    if
-//  ^^ keyword.control.go
-    range
-//  ^^^^^ keyword.other.go
-    return
-//  ^^^^^^ keyword.control.go
-    select
-//  ^^^^^^ keyword.control.go
-    switch
-//  ^^^^^^ keyword.control.go
-
-// ## func
-
-// Note: function signatures are thoroughly tested in the section of this test
-// file dedicated to types. The part after the function name (parameters and
-// return signature) is EXACTLY the same for function declarations, method
-// declarations, anonymous functions, and function types.
-
-    func() {}
-//  ^^^^ storage.type.keyword.function.go
-//      ^ punctuation.section.parens.begin.go
-//       ^ punctuation.section.parens.end.go
-//         ^ meta.block.go punctuation.section.braces.begin.go
-//          ^ meta.block.go punctuation.section.braces.end.go
-
-    func ident() {}
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^^ entity.name.function.go
-//            ^ punctuation.section.parens.begin.go
-//             ^ punctuation.section.parens.end.go
-//               ^ meta.block.go punctuation.section.braces.begin.go
-//                ^ meta.block.go punctuation.section.braces.end.go
-
-    func ident /**/ () {}
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^^ entity.name.function.go
-//             ^^^^ comment.block.go
-
-    func ident /* * */ () {}
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^^ entity.name.function.go
-//             ^^^^^^^ comment.block.go
-
-    func ident(
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^^ entity.name.function.go
-        param typ
-//      ^^^^^ variable.parameter.go
-//            ^^^ storage.type.go
-    ) typ {}
-//    ^^^ storage.type.go
-
-// Methods
-
-    func (self Type) Method() {}
-//       ^ meta.function.declaration.go punctuation.section.parens.begin.go
-//        ^^^^ meta.function.declaration.go variable.parameter.go
-//             ^^^^ meta.function.declaration.go storage.type.go
-//                 ^ meta.function.declaration.go punctuation.section.parens.end.go
-//                   ^^^^^^ meta.function.declaration.go entity.name.function.go
-//                         ^ punctuation.section.parens.begin.go
-//                          ^ punctuation.section.parens.end.go
-
-    func (Type) Method() {}
-//  ^^^^ storage.type.keyword.function.go
-//       ^ meta.function.declaration.go punctuation.section.parens.begin.go
-//        ^^^^ meta.function.declaration.go storage.type.go
-//            ^ meta.function.declaration.go punctuation.section.parens.end.go
-//              ^^^^^^ meta.function.declaration.go entity.name.function.go
-//                    ^ punctuation.section.parens.begin.go
-//                     ^ punctuation.section.parens.end.go
-
-    func /**/
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^^ comment.block.go
-    ( /**/ self /**/ * /**/ ident /**/ . /**/ Type /**/ ) /**/ Method /**/ (
-//  ^ meta.function.declaration.go punctuation.section.parens.begin.go
-//    ^^^^ meta.function.declaration.go comment.block.go
-//         ^^^^ meta.function.declaration.go variable.parameter.go
-//              ^^^^ meta.function.declaration.go comment.block.go
-//                   ^ meta.function.declaration.go keyword.operator.go
-//                     ^^^^ meta.function.declaration.go comment.block.go
-//                          ^^^^^ meta.function.declaration.go variable.other.go
-//                                ^^^^ meta.function.declaration.go comment.block.go
-//                                     ^ meta.function.declaration.go punctuation.accessor.dot.go
-//                                       ^^^^ meta.function.declaration.go comment.block.go
-//                                            ^^^^ meta.function.declaration.go storage.type.go
-//                                                 ^^^^ meta.function.declaration.go comment.block.go
-//                                                      ^ meta.function.declaration.go punctuation.section.parens.end.go
-//                                                        ^^^^ meta.function.declaration.go comment.block.go
-//                                                             ^^^^^^ meta.function.declaration.go entity.name.function.go
-//                                                                    ^^^^ comment.block.go
-        param typ
-//      ^^^^^ variable.parameter.go
-//            ^^^ storage.type.go
-    ) typ {}
-//    ^^^ storage.type.go
-//        ^ meta.block.go punctuation.section.braces.begin.go
-//         ^ meta.block.go punctuation.section.braces.end.go
-
-
-// # Predeclared Constants
-
-    true false nil
-//  ^^^^ constant.language.go
-//       ^^^^^ constant.language.go
-//             ^^^ constant.language.go
-
-
-// # Built-in Types
-
-/*
-These tests make sure that the treatment of built-ins is consistent with
-non-built-ins and is purely additive.
-
-Due to how they're combined in the syntax definition, we don't need to test
-every type individually.
-*/
-
-    chan typ
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^ storage.type.go -support
-
-    chan int
-//  ^^^^ storage.type.keyword.chan.go
-//       ^^^ storage.type.go support.type.builtin.go
-
-    func(typ)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^ storage.type.go -support
-
-    func(int)
-//  ^^^^ storage.type.keyword.function.go
-//       ^^^ storage.type.go support.type.builtin.go
-
-    map[typ]typ
-//  ^^^ storage.type.keyword.map.go
-//      ^^^ storage.type.go -support
-//          ^^^ storage.type.go -support
-
-    map[int]int
-//  ^^^ storage.type.keyword.map.go
-//      ^^^ storage.type.go support.type.builtin.go
-//          ^^^ storage.type.go support.type.builtin.go
-
-    struct { ident typ; typ }
-//  ^^^^^^ storage.type.keyword.struct.go
-//           ^^^^^ meta.type.go variable.other.member.declaration.go
-//                 ^^^ meta.type.go storage.type.go -support
-//                      ^^^ meta.type.go entity.other.inherited-class.go -support
-
-    struct { ident int; int }
-//  ^^^^^^ storage.type.keyword.struct.go
-//           ^^^^^ meta.type.go variable.other.member.declaration.go
-//                 ^^^ meta.type.go storage.type.go support.type.builtin.go
-//                      ^^^ meta.type.go entity.other.inherited-class.go support.type.builtin.go
-
-    interface { typ }
-//  ^^^^^^^^^ storage.type.keyword.interface.go
-//              ^^^ meta.type.go entity.other.inherited-class.go -support
-
-    interface { error }
-//  ^^^^^^^^^ storage.type.keyword.interface.go
-//              ^^^^^ meta.type.go entity.other.inherited-class.go support.type.builtin.go
-
-    [...]typ
-//   ^^^ keyword.operator.variadic.go
-//       ^^^ storage.type.go -support
-
-    [...]int
-//   ^^^ keyword.operator.variadic.go
-//       ^^^ storage.type.go support.type.builtin.go
-
-    []typ
-//    ^^^ storage.type.go -support
-
-    []int
-//    ^^^ storage.type.go support.type.builtin.go
-
-    type _ typ
-//  ^^^^ storage.type.keyword.type.go
-//       ^ variable.language.blank.go
-//         ^^^ storage.type.go -support
-
-    type _ int
-//  ^^^^ storage.type.keyword.type.go
-//       ^ variable.language.blank.go
-//         ^^^ storage.type.go support.type.builtin.go
-
-    const ident typ
-//  ^^^^^ storage.type.keyword.const.go
-//        ^^^^^ variable.other.constant.declaration.go
-//              ^^^ storage.type.go -support
-
-    const ident int
-//  ^^^^^ storage.type.keyword.const.go
-//        ^^^^^ variable.other.constant.declaration.go
-//              ^^^ storage.type.go support.type.builtin.go
-
-    var ident typ
-//  ^^^ storage.type.keyword.var.go
-//      ^^^^^ variable.declaration.go
-//            ^^^ storage.type.go -support
-
-    var ident int
-//  ^^^ storage.type.keyword.var.go
-//      ^^^^^ variable.declaration.go
-//            ^^^ storage.type.go support.type.builtin.go
-
-    ident.(typ)
-//  ^^^^^ variable.other.go
-//         ^^^ storage.type.go -support
-
-    ident.(int)
-//  ^^^^^ variable.other.go
-//         ^^^ storage.type.go support.type.builtin.go
-
-    (typ)(ident)
-//   ^^^ variable.function.go -support
-//        ^^^^^ variable.other.go
-
-    (int)(ident)
-//   ^^^ variable.function.go support.type.builtin.go
-//        ^^^^^ variable.other.go
-
-
-// # Built-in Functions
-
-// ## Special Functions
-
-    make(typ)
-//  ^^^^ variable.function.go support.function.builtin.go
-//       ^^^ storage.type.go -support
-
-    make(int)
-//  ^^^^ variable.function.go support.function.builtin.go
-//       ^^^ storage.type.go support.type.builtin.go
-
-    make /**/ (
-//  ^^^^ variable.function.go support.function.builtin.go
-//       ^^^^ comment.block.go
-        /**/ typ /**/,
-//      ^^^^ comment.block.go
-//           ^^^ storage.type.go -support
-//               ^^^^ comment.block.go
-        ident,
-//      ^^^^^ variable.other.go
-        ident,
-//      ^^^^^ variable.other.go
-    )
-
-    make /**/ (
-//  ^^^^ variable.function.go support.function.builtin.go
-//       ^^^^ comment.block.go
-        /**/ int /**/,
-//      ^^^^ comment.block.go
-//           ^^^ storage.type.go support.type.builtin.go
-//               ^^^^ comment.block.go
-        ident,
-//      ^^^^^ variable.other.go
-        ident,
-//      ^^^^^ variable.other.go
-    )
-
-    make
-//  ^^^^ variable.other.go -support
-
-    var make
-//  ^^^ storage.type.keyword.var.go
-//      ^^^^ variable.declaration.go -support
-
-    new(typ, ident)
-//  ^^^ variable.function.go support.function.builtin.go
-//      ^^^ storage.type.go -support
-//           ^^^^^ variable.other.go
-
-    new(int, ident)
-//  ^^^ variable.function.go support.function.builtin.go
-//      ^^^ storage.type.go support.type.builtin.go
-//           ^^^^^ variable.other.go
-
-    ((new))(typ, ident)
-//    ^^^ variable.function.go support.function.builtin.go
-//          ^^^ storage.type.go -support
-//               ^^^^^ variable.other.go
-
-    ((new))(int, ident)
-//    ^^^ variable.function.go support.function.builtin.go
-//          ^^^ storage.type.go support.type.builtin.go
-//               ^^^^^ variable.other.go
-
-    new /**/ (
-//  ^^^ variable.function.go support.function.builtin.go
-//      ^^^^ comment.block.go
-        /**/ typ /**/ ,
-//      ^^^^ comment.block.go
-//           ^^^ storage.type.go -support
-//               ^^^^ comment.block.go
-    )
-
-    new /**/ (
-//  ^^^ variable.function.go support.function.builtin.go
-//      ^^^^ comment.block.go
-        /**/ int /**/ ,
-//      ^^^^ comment.block.go
-//           ^^^ storage.type.go support.type.builtin.go
-//               ^^^^ comment.block.go
-    )
-
-    new
-//  ^^^ variable.other.go -support
-
-    var new
-//  ^^^ storage.type.keyword.var.go
-//      ^^^ variable.declaration.go -support
-
-// ## Other Functions
-
-/*
-These tests make sure that the treatment of built-ins is consistent with
-non-built-ins, is purely additive, and sufficiently limited.
-
-Due to how they're combined in the syntax definition, we don't need to test
-every function individually.
-*/
-
-    ident(ident)
-//  ^^^^^ variable.function.go -support
-//        ^^^^^ variable.other.go
-
-    close(ident)
-//  ^^^^^ variable.function.go support.function.builtin.go
-//        ^^^^^ variable.other.go
-
-    ((ident))(ident)
-//    ^^^^^ variable.function.go -support
-//            ^^^^^ variable.other.go
-
-    ((close))(ident)
-//    ^^^^^ variable.function.go support.function.builtin.go
-//            ^^^^^ variable.other.go
-
-    close
-//  ^^^^^ variable.other.go -support
-
-    var close
-//  ^^^ storage.type.keyword.var.go
-//      ^^^^^ variable.declaration.go -support
+// SYNTAX TEST "Packages/Go/Go.sublime-syntax"
+package examples
+
+import (
+// <- meta.import keyword.control.import
+//^^^^^^ meta.import
+//     ^ meta.group punctuation.definition.group
+	"fmt"
+	//^^^ meta.import meta.group
+	// <- string.quoted.double
+	//^^^ string.quoted.double
+)
+// <- meta.import meta.group punctuation.definition.group
+
+import "strings"
+// <- meta.import keyword.control.import
+//^^^^^^^^^^^^^^ meta.import
+//     ^^^^^^^^^ string.quoted.double
+
+var valid int = 0
+// <- meta.initialization.explicit storage.type
+//  ^^^^^ meta.initialization.explicit variable.other
+
+var var1, var2, var3
+// <- meta.initialization.explicit storage.type
+//  ^ variable.other
+//      ^ punctuation.separator - variable.other
+//        ^ variable.other
+//            ^ punctuation.separator - variable.other
+//              ^ variable.other
+
+var1 := 1
+// <- meta.initialization.short variable.other
+//   ^^ keyword.operator.initialize
+
+var1, var2 := imported.Vals
+// <- meta.initialization.short variable.other
+//^^^^^^^^^^^ meta.initialization.short
+//  ^ punctuation.separator - variable.other
+//    ^ variable.other
+//         ^^ keyword.operator.initialize
+
+fmt.Println("case message := <- obj.channel")
+//  ^ variable.function
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted
+
+var (
+// <- meta.initialization.multiple storage.type
+//  ^ meta.group punctuation.definition.group
+	//  var commented int = 0
+	//  ^ comment.line
+
+	variable = 1
+	var2, var3 = func_call()
+	var3 = string(123)
+)
+// <- meta.group punctuation.definition.group
+
+func test(data MyStruct)
+{
+	data.fooBar
+	//  ^ punctuation.accessor
+	//   ^^^^^^ variable.other.member
+}
+
+const (
+	graveAccentString = `highlights %s and %[1]s`
+	//                              ^ constant.other.placeholder
+	//                                      ^ constant.other.placeholder
+	normalString = "highlights %q and %[1]s"
+	//                          ^ constant.other.placeholder
+	//                                 ^ constant.other.placeholder
+	dynamicFieldWidths = "test string %[1]*.[2]*f %*.*f"
+	//                                  ^ constant.other.placeholder
+	//                                              ^ constant.other.placeholder
+)
+
+type myStruct struct {
+//^^^^^^^^^^^^^^^^^^^^ meta.struct
+// <- storage.type
+//   ^^^^^^^^ entity.name.struct
+//            ^ storage.type
+//                   ^ meta.block punctuation.definition.block.begin
+	Field1 string          `tag1:""`
+	// <- variable.other.member
+	//     ^ storage.type
+	//                     ^ string.quoted
+	Field2 []string        `tag1:""`
+	// <- variable.other.member
+	//     ^^ meta.brackets
+	//     ^ punctuation.definition.brackets.begin
+	//      ^ punctuation.definition.brackets.end
+	//       ^ storage.type
+	//                     ^ string.quoted
+	Field3 interface{}     `tag1:""`
+	// <- variable.other.member
+	//     ^ storage.type
+	//              ^^ meta.block
+	//              ^ punctuation.definition.block.begin
+	//               ^ punctuation.definition.block.end
+	//                     ^ string.quoted
+	field4 map[string]uint `tag1:""`
+	// <- variable.other.member
+	//     ^ storage.type
+	//        ^^^^^^^^ meta.brackets
+	//        ^ punctuation.definition.brackets.begin
+	//         ^ storage.type
+	//               ^ punctuation.definition.brackets.end
+	//                ^ storage.type
+	//                     ^ string.quoted
+	field5 package.MyType  `tag1:""`
+	// <- variable.other.member
+	package.MyOtherType
+	//^^^^^^ - variable.other.member
+	//      ^ variable.other.member
+	*LocalType
+	// <- keyword.operator
+	//^ variable.other.member
+}
+// <- meta.struct meta.block punctuation.definition.block.end
+
+type FuncContainer struct {
+	FirstFunc   func(arg string)
+	// <- variable.other.member
+	//          ^^^^^^^^^^^^^^^^ meta.function
+	//          ^ storage.type
+	//               ^^^ variable.parameter
+	//                   ^ storage.type
+	SecondFunc  func(arg interface{})
+	// <- variable.other.member
+	//          ^^^^^^^^^^^^^^^^ meta.function
+	//          ^ storage.type
+	//               ^^^ variable.parameter
+	//                   ^ storage.type
+	SeventhFunc func(arg string)
+	// <- variable.other.member
+	//          ^^^^^^^^^^^^^^^^ meta.function
+	//          ^ storage.type
+	//               ^^^ variable.parameter
+	//                   ^ storage.type
+}
+
+type LocalType /* Comment */ map[int32]int64
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type
+// <- storage.type
+//   ^^^^^^^^^ entity.name.type
+//             ^^^^^^^^^^^^^ comment.block
+//                           ^ storage.type
+//                              ^^^^^^^ meta.brackets
+//                              ^ punctuation.definition.brackets.begin
+//                                    ^ punctuation.definition.brackets.end
+
+func myFunc (nonHighlightedPrimitiveArg string, foo bar) {
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//^^^^^^^^^ meta.function.declaration
+//         ^ - meta.function.declaration
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
+//                                                      ^ - meta.function.parameters
+// ^ storage.type
+//     ^ entity.name.function
+//            ^ variable.parameter
+//                                      ^ storage.type - variable
+//                                            ^ punctuation.separator - variable
+//                                              ^ variable.parameter
+//                                                  ^ - variable
+//                                                       ^ meta.block punctuation.definition.block
+	return "test string"
+//  ^ meta.function meta.block keyword.control
+//            ^ string.quoted.double
+}
+
+func myFunc3(param /* */ , param2 string, param3 package.MyType) {
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//   ^ entity.name.function
+//           ^ variable.parameter
+//                 ^^^^^ comment.block
+//                       ^ punctuation.separator
+//                         ^ variable.parameter
+//                                ^ storage.type
+}
+
+func
+// <- storage.type
+
+func myFunc2(nonHighlightedPrimitiveArg string,/* */  foo, foobaz bar) (nonHighlightedPrimitiveReturn, anotherType) {
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//^^^^^^^^^^ meta.function.declaration
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
+//                                                                    ^ - meta.function.parameters
+//                                                                    ^ - meta.function.return-type
+//                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.return-type
+//                                                                                                                 ^ - meta.function.return-type
+// ^ storage.type
+//     ^ entity.name.function
+//            ^ variable.parameter
+//                                      ^ storage.type
+//                                            ^ punctuation.separator - variable
+//                                             ^^^^^ comment.block
+//                                                    ^ variable.parameter
+//                                                         ^ variable.parameter
+//                                                               ^ - variable
+//                                                                   ^ meta.group punctuation.definition.group.end
+//                                                                     ^ meta.group punctuation.definition.group.begin
+//                                                                                                   ^ punctuation.separator
+	return "test string"
+	// <- meta.function meta.block keyword.control
+	//      ^ string.quoted.double
+}
+
+func (v *Type) myFunc(nonHighlightedPrimitiveArg /* Test, comments(!) */ [10]string, foo bar) (
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+//                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters - meta.function.declaration
+//                                                                                           ^ - meta.function.parameters
+//                                                                                           ^ - meta.function.return-type
+//                                                                                            ^ meta.function.return-type
+// ^ storage.type
+//    ^ variable.parameter.receiver
+//               ^ entity.name.function
+//                       ^ variable.parameter
+	nonHighlightedPrimitiveReturn, anotherType) {
+	// ^ meta.function.return-type
+	//                           ^ punctuation.separator
+	variable[5].foo()
+	//      ^^^ meta.brackets
+	//      ^ punctuation.definition.brackets.begin.go
+	//       ^ constant.numeric.integer.decimal
+	//        ^ punctuation.definition.brackets.end.go
+	//         ^^^^^^ meta.function-call.method
+	//         ^ punctuation.accessor
+	//             ^^ meta.group
+	//             ^ punctuation.definition.group.begin
+	//              ^ punctuation.definition.group.end
+	return ""
+	// <- meta.function meta.block keyword.control
+}
+
+func () {
+// <- storage.type
+//^^^^^^^ meta.function
+//   ^^ meta.function.parameters meta.group
+//   ^ punctuation.definition.group.begin
+//    ^ punctuation.definition.group.end
+//     ^ - meta.function.parameters
+//     ^ - meta.function.return-type
+}
+
+type funcTypeExample func(param one) (myType)
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type
+//   ^^^^^^^^^^^^^^^ entity.name.type
+//                   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//                   ^^^^ meta.function.declaration.anonymous
+//                       ^^^^^^^^^^^ meta.function.parameters
+//                        ^ variable.parameter
+//                              ^ - variable.parameter
+//                                  ^ - meta.function.parameters
+//                                  ^ - meta.function.return-type
+//                                   ^^^^^^^^ meta.function.return-type meta.group
+//                                   ^ punctuation.definition.group.begin
+//                                          ^ punctuation.definition.group.end
+
+func (t funcTypeExample) foobar() {}
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration
+// ^ storage.type
+//    ^ variable.parameter.receiver
+//                       ^ entity.name.function
+//                             ^^ meta.function.parameters meta.group
+//                                ^^ meta.block
+
+func () {
+	switch {
+	// <- keyword.control
+	//     ^ punctuation.definition.block.begin
+	case byte, rune, string:
+	// <- keyword.control
+	//   ^^^^ storage.type
+	//       ^ punctuation.separator
+	//         ^^^^ storage.type
+	//             ^ punctuation.separator
+	//               ^^^^^^ storage.type
+	//                     ^ punctuation.separator
+	case 1, 1.23, "str", 'c', true, false, 0xff:
+	// <- keyword.control
+	//   ^ constant.numeric.integer.decimal
+	//    ^ punctuation.separator
+	//      ^^^^ constant.numeric.float.decimal
+	//          ^ punctuation.separator
+	//            ^^^^^ string.quoted.double
+	//                 ^ punctuation.separator
+	//                   ^^^ string.quoted.single
+	//                      ^ punctuation.separator
+	//                        ^^^^ constant.language
+	//                            ^ punctuation.separator
+	//                              ^^^^^ constant.language
+	//                                   ^ punctuation.separator
+	//                                     ^^^^ constant.numeric.integer.hexadecimal
+	//                                     ^^ punctuation.definition.numeric.hexadecimal
+	//                                         ^ punctuation.separator
+		fallthrough
+		// <- keyword.control
+	default:
+	// <- keyword.control
+	//     ^ punctuation.separator
+	}
+	// <- punctuation.definition.block.end
+
+	Label:
+	// <- entity.name.label
+	//   ^ punctuation.separator
+}


### PR DESCRIPTION
The most recent go syntax definition doesn't work with syntect
(see https://github.com/trishume/syntect/issues/228) so this
replaces it with an older, working version.